### PR TITLE
git gui: fix branch name encoding error on git gui

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -684,6 +684,7 @@ proc load_current_branch {} {
 	global current_branch is_detached
 
 	set fd [open [gitdir HEAD] r]
+	fconfigure $fd -translation binary -encoding utf-8
 	if {[gets $fd ref] < 1} {
 		set ref {}
 	}

--- a/lib/branch.tcl
+++ b/lib/branch.tcl
@@ -8,6 +8,7 @@ proc load_all_heads {} {
 	set rh_len [expr {[string length $rh] + 1}]
 	set all_heads [list]
 	set fd [git_read for-each-ref --format=%(refname) $rh]
+	fconfigure $fd -translation binary -encoding utf-8
 	while {[gets $fd line] > 0} {
 		if {!$some_heads_tracking || ![is_tracking_branch $line]} {
 			lappend all_heads [string range $line $rh_len end]
@@ -24,6 +25,7 @@ proc load_all_tags {} {
 		--sort=-taggerdate \
 		--format=%(refname) \
 		refs/tags]
+	fconfigure $fd -translation binary -encoding utf-8
 	while {[gets $fd line] > 0} {
 		if {![regsub ^refs/tags/ $line {} name]} continue
 		lappend all_tags $name


### PR DESCRIPTION
After "git checkout -b '漢字'" to create a branch with UTF-8
character in it, "git gui" shows the branch name incorrectly,
as it forgets to turn the bytes
read from the "git for-each-ref" and
read from "HEAD" file
into Unicode characters.

Signed-off-by: Kazuhiro Kato <kato-k@ksysllc.co.jp>