### PR TITLE
Backport a Git GUI change that was included in Git v2.39.0-rc2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ ifeq ($(uname_S),Darwin)
 	TKEXECUTABLE = $(shell basename "$(TKFRAMEWORK)" .app)
 endif
 
-ifeq ($(findstring $(MAKEFLAGS),s),s)
+ifeq ($(findstring $(firstword -$(MAKEFLAGS)),s),s)
 QUIET_GEN =
 endif
 


### PR DESCRIPTION
The `Makefile` of Git GUI was modified as part of [a larger patch in git/git](https://github.com/git/git/commit/cddd68ae33667c4bfc81c81f74815bb2ba0e4f3a) instead of the more canonical approach of applying the patch to Git GUI first and then requesting to pull Git GUI into Git.

Let's backport the Git GUI-specific part back into Git GUI.