### PR TITLE
git-gui: add support for filenames starting with tilde

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -2338,6 +2338,7 @@ proc do_explore {} {
 # Open file relative to the working tree by the default associated app.
 proc do_file_open {file} {
 	global _gitworktree
+	if {[string index $file 0] eq {~}} {set file ./$file}
 	set explorer [get_explorer]
 	set full_file_path [file join $_gitworktree $file]
 	exec $explorer [file nativename $full_file_path] &

--- a/lib/diff.tcl
+++ b/lib/diff.tcl
@@ -190,6 +190,7 @@ proc show_other_diff {path w m cont_info} {
 		set max_sz 100000
 		set type unknown
 		if {[catch {
+				if {[string index $path 0] eq {~}} {set path ./$path}
 				set type [file type $path]
 				switch -- $type {
 				directory {

--- a/lib/index.tcl
+++ b/lib/index.tcl
@@ -617,7 +617,7 @@ proc delete_helper {path_list path_index deletion_errors batch_size \
 
 		set path [lindex $path_list $path_index]
 
-		set deletion_failed [catch {file delete -- $path} deletion_error]
+		set deletion_failed [catch {file delete -- ./$path} deletion_error]
 
 		if {$deletion_failed} {
 			lappend deletion_errors [list "$deletion_error"]


### PR DESCRIPTION
When working with literal filenames that start with a tilde, we need to work around TCL helpfully expanding that into a users home directory.

I hope I've caught all the issues with filenames like `~.txt`.

This fixes https://github.com/git-for-windows/git/issues/4349