### PR TITLE
git-gui: Add option to wrap overlong lines in the commit message field.

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -947,6 +947,7 @@ set default_config(gui.blamehistoryctx) 7
 set default_config(gui.diffcontext) 5
 set default_config(gui.diffopts) {}
 set default_config(gui.commitmsgwidth) 75
+set default_config(gui.commitmsgwrap) false
 set default_config(gui.newbranchtemplate) {}
 set default_config(gui.spellingdictionary) {}
 set default_config(gui.fontui) [font configure font_ui]
@@ -3504,6 +3505,12 @@ if {![is_enabled nocommit]} {
 	pack .vpane.lower.commarea.buffer.header.amend -side right
 }
 
+if {$repo_config(gui.commitmsgwrap)} {
+	set comm_wrap word
+} else {
+	set comm_wrap none
+}
+
 textframe .vpane.lower.commarea.buffer.frame
 ttext $ui_comm \
 	-borderwidth 1 \
@@ -3513,7 +3520,7 @@ ttext $ui_comm \
 	-takefocus 1 \
 	-highlightthickness 1 \
 	-relief sunken \
-	-width $repo_config(gui.commitmsgwidth) -height 9 -wrap none \
+	-width $repo_config(gui.commitmsgwidth) -height 9 -wrap $comm_wrap \
 	-font font_diff \
 	-xscrollcommand {.vpane.lower.commarea.buffer.frame.sbx set} \
 	-yscrollcommand {.vpane.lower.commarea.buffer.frame.sby set}

--- a/lib/option.tcl
+++ b/lib/option.tcl
@@ -156,6 +156,7 @@ proc do_options {} {
 		{i-1..99 gui.diffcontext {mc "Number of Diff Context Lines"}}
 		{t gui.diffopts {mc "Additional Diff Parameters"}}
 		{i-0..99 gui.commitmsgwidth {mc "Commit Message Text Width"}}
+		{b gui.commitmsgwrap {mc "Commit Message Wrap Lines"}}
 		{t gui.newbranchtemplate {mc "New Branch Name Template"}}
 		{c gui.encoding {mc "Default File Contents Encoding"}}
 		{b gui.warndetachedcommit {mc "Warn before committing to a detached head"}}

--- a/po/git-gui.pot
+++ b/po/git-gui.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-08 22:54+0100\n"
+"POT-Creation-Date: 2023-05-03 19:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,33 +17,33 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: git-gui.sh:847
+#: git-gui.sh:846
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr ""
 
-#: git-gui.sh:901
+#: git-gui.sh:902
 msgid "Main Font"
 msgstr ""
 
-#: git-gui.sh:902
+#: git-gui.sh:903
 msgid "Diff/Console Font"
 msgstr ""
 
-#: git-gui.sh:917 git-gui.sh:931 git-gui.sh:944 git-gui.sh:1034 git-gui.sh:1053
-#: git-gui.sh:3212
+#: git-gui.sh:918 git-gui.sh:932 git-gui.sh:945 git-gui.sh:1035 git-gui.sh:1054
+#: git-gui.sh:3221
 msgid "git-gui: fatal error"
 msgstr ""
 
-#: git-gui.sh:918
+#: git-gui.sh:919
 msgid "Cannot find git in PATH."
 msgstr ""
 
-#: git-gui.sh:945
+#: git-gui.sh:946
 msgid "Cannot parse Git version string:"
 msgstr ""
 
-#: git-gui.sh:970
+#: git-gui.sh:971
 #, tcl-format
 msgid ""
 "Git version cannot be determined.\n"
@@ -55,518 +55,518 @@ msgid ""
 "Assume '%s' is version 1.5.0?\n"
 msgstr ""
 
-#: git-gui.sh:1267
+#: git-gui.sh:1268
 msgid "Git directory not found:"
 msgstr ""
 
-#: git-gui.sh:1301
+#: git-gui.sh:1302
 msgid "Cannot move to top of working directory:"
 msgstr ""
 
-#: git-gui.sh:1309
+#: git-gui.sh:1310
 msgid "Cannot use bare repository:"
 msgstr ""
 
-#: git-gui.sh:1317
+#: git-gui.sh:1318
 msgid "No working directory"
 msgstr ""
 
-#: git-gui.sh:1491 lib/checkout_op.tcl:306
+#: git-gui.sh:1493 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr ""
 
-#: git-gui.sh:1551
+#: git-gui.sh:1553
 msgid "Scanning for modified files ..."
 msgstr ""
 
-#: git-gui.sh:1629
+#: git-gui.sh:1637
 msgid "Calling prepare-commit-msg hook..."
 msgstr ""
 
-#: git-gui.sh:1646
+#: git-gui.sh:1654
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr ""
 
-#: git-gui.sh:1804 lib/browser.tcl:252
+#: git-gui.sh:1812 lib/browser.tcl:252
 msgid "Ready."
 msgstr ""
 
-#: git-gui.sh:1968
+#: git-gui.sh:1976
 #, tcl-format
 msgid ""
 "Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
 msgstr ""
 
-#: git-gui.sh:2091
+#: git-gui.sh:2099
 msgid "Unmodified"
 msgstr ""
 
-#: git-gui.sh:2093
+#: git-gui.sh:2101
 msgid "Modified, not staged"
 msgstr ""
 
-#: git-gui.sh:2094 git-gui.sh:2106
+#: git-gui.sh:2102 git-gui.sh:2114
 msgid "Staged for commit"
 msgstr ""
 
-#: git-gui.sh:2095 git-gui.sh:2107
+#: git-gui.sh:2103 git-gui.sh:2115
 msgid "Portions staged for commit"
 msgstr ""
 
-#: git-gui.sh:2096 git-gui.sh:2108
+#: git-gui.sh:2104 git-gui.sh:2116
 msgid "Staged for commit, missing"
 msgstr ""
 
-#: git-gui.sh:2098
+#: git-gui.sh:2106
 msgid "File type changed, not staged"
 msgstr ""
 
-#: git-gui.sh:2099 git-gui.sh:2100
+#: git-gui.sh:2107 git-gui.sh:2108
 msgid "File type changed, old type staged for commit"
 msgstr ""
 
-#: git-gui.sh:2101
+#: git-gui.sh:2109
 msgid "File type changed, staged"
 msgstr ""
 
-#: git-gui.sh:2102
+#: git-gui.sh:2110
 msgid "File type change staged, modification not staged"
 msgstr ""
 
-#: git-gui.sh:2103
+#: git-gui.sh:2111
 msgid "File type change staged, file missing"
 msgstr ""
 
-#: git-gui.sh:2105
+#: git-gui.sh:2113
 msgid "Untracked, not staged"
 msgstr ""
 
-#: git-gui.sh:2110
+#: git-gui.sh:2118
 msgid "Missing"
 msgstr ""
 
-#: git-gui.sh:2111
+#: git-gui.sh:2119
 msgid "Staged for removal"
 msgstr ""
 
-#: git-gui.sh:2112
+#: git-gui.sh:2120
 msgid "Staged for removal, still present"
 msgstr ""
 
-#: git-gui.sh:2114 git-gui.sh:2115 git-gui.sh:2116 git-gui.sh:2117
-#: git-gui.sh:2118 git-gui.sh:2119
+#: git-gui.sh:2122 git-gui.sh:2123 git-gui.sh:2124 git-gui.sh:2125
+#: git-gui.sh:2126 git-gui.sh:2127
 msgid "Requires merge resolution"
 msgstr ""
 
-#: git-gui.sh:2164
+#: git-gui.sh:2172
 msgid "Couldn't find gitk in PATH"
 msgstr ""
 
-#: git-gui.sh:2210 git-gui.sh:2245
+#: git-gui.sh:2219 git-gui.sh:2255
 #, tcl-format
 msgid "Starting %s... please wait..."
 msgstr ""
 
-#: git-gui.sh:2224
+#: git-gui.sh:2234
 msgid "Couldn't find git gui in PATH"
 msgstr ""
 
-#: git-gui.sh:2726 lib/choose_repository.tcl:53
+#: git-gui.sh:2735 lib/choose_repository.tcl:53
 msgid "Repository"
 msgstr ""
 
-#: git-gui.sh:2727
+#: git-gui.sh:2736
 msgid "Edit"
 msgstr ""
 
-#: git-gui.sh:2729 lib/choose_rev.tcl:567
+#: git-gui.sh:2738 lib/choose_rev.tcl:567
 msgid "Branch"
 msgstr ""
 
-#: git-gui.sh:2732 lib/choose_rev.tcl:554
+#: git-gui.sh:2741 lib/choose_rev.tcl:554
 msgid "Commit@@noun"
 msgstr ""
 
-#: git-gui.sh:2735 lib/merge.tcl:127 lib/merge.tcl:174
+#: git-gui.sh:2744 lib/merge.tcl:127 lib/merge.tcl:174
 msgid "Merge"
 msgstr ""
 
-#: git-gui.sh:2736 lib/choose_rev.tcl:563
+#: git-gui.sh:2745 lib/choose_rev.tcl:563
 msgid "Remote"
 msgstr ""
 
-#: git-gui.sh:2739
+#: git-gui.sh:2748
 msgid "Tools"
 msgstr ""
 
-#: git-gui.sh:2748
+#: git-gui.sh:2757
 msgid "Explore Working Copy"
 msgstr ""
 
-#: git-gui.sh:2763
+#: git-gui.sh:2772
 msgid "Git Bash"
 msgstr ""
 
-#: git-gui.sh:2772
+#: git-gui.sh:2781
 msgid "Browse Current Branch's Files"
 msgstr ""
 
-#: git-gui.sh:2776
+#: git-gui.sh:2785
 msgid "Browse Branch Files..."
 msgstr ""
 
-#: git-gui.sh:2781
+#: git-gui.sh:2790
 msgid "Visualize Current Branch's History"
 msgstr ""
 
-#: git-gui.sh:2785
+#: git-gui.sh:2794
 msgid "Visualize All Branch History"
 msgstr ""
 
-#: git-gui.sh:2792
+#: git-gui.sh:2801
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr ""
 
-#: git-gui.sh:2794
+#: git-gui.sh:2803
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr ""
 
-#: git-gui.sh:2799 lib/database.tcl:40
+#: git-gui.sh:2808 lib/database.tcl:40
 msgid "Database Statistics"
 msgstr ""
 
-#: git-gui.sh:2802 lib/database.tcl:33
+#: git-gui.sh:2811 lib/database.tcl:33
 msgid "Compress Database"
 msgstr ""
 
-#: git-gui.sh:2805
+#: git-gui.sh:2814
 msgid "Verify Database"
 msgstr ""
 
-#: git-gui.sh:2812 git-gui.sh:2816 git-gui.sh:2820
+#: git-gui.sh:2821 git-gui.sh:2825 git-gui.sh:2829
 msgid "Create Desktop Icon"
 msgstr ""
 
-#: git-gui.sh:2828 lib/choose_repository.tcl:209 lib/choose_repository.tcl:217
+#: git-gui.sh:2837 lib/choose_repository.tcl:209 lib/choose_repository.tcl:217
 msgid "Quit"
 msgstr ""
 
-#: git-gui.sh:2836
+#: git-gui.sh:2845
 msgid "Undo"
 msgstr ""
 
-#: git-gui.sh:2839
+#: git-gui.sh:2848
 msgid "Redo"
 msgstr ""
 
-#: git-gui.sh:2843 git-gui.sh:3461
+#: git-gui.sh:2852 git-gui.sh:3487
 msgid "Cut"
 msgstr ""
 
-#: git-gui.sh:2846 git-gui.sh:3464 git-gui.sh:3540 git-gui.sh:3633
+#: git-gui.sh:2855 git-gui.sh:3490 git-gui.sh:3566 git-gui.sh:3659
 #: lib/console.tcl:69
 msgid "Copy"
 msgstr ""
 
-#: git-gui.sh:2849 git-gui.sh:3467
+#: git-gui.sh:2858 git-gui.sh:3493
 msgid "Paste"
 msgstr ""
 
-#: git-gui.sh:2852 git-gui.sh:3470 lib/remote_branch_delete.tcl:39
-#: lib/branch_delete.tcl:28
+#: git-gui.sh:2861 git-gui.sh:3496 lib/branch_delete.tcl:28
+#: lib/remote_branch_delete.tcl:39
 msgid "Delete"
 msgstr ""
 
-#: git-gui.sh:2856 git-gui.sh:3474 git-gui.sh:3637 lib/console.tcl:71
+#: git-gui.sh:2865 git-gui.sh:3500 git-gui.sh:3663 lib/console.tcl:71
 msgid "Select All"
 msgstr ""
 
-#: git-gui.sh:2865
+#: git-gui.sh:2874
 msgid "Create..."
 msgstr ""
 
-#: git-gui.sh:2871
+#: git-gui.sh:2880
 msgid "Checkout..."
 msgstr ""
 
-#: git-gui.sh:2877
+#: git-gui.sh:2886
 msgid "Rename..."
 msgstr ""
 
-#: git-gui.sh:2882
+#: git-gui.sh:2891
 msgid "Delete..."
 msgstr ""
 
-#: git-gui.sh:2887
+#: git-gui.sh:2896
 msgid "Reset..."
 msgstr ""
 
-#: git-gui.sh:2897
+#: git-gui.sh:2906
 msgid "Done"
 msgstr ""
 
-#: git-gui.sh:2899
+#: git-gui.sh:2908
 msgid "Commit@@verb"
 msgstr ""
 
-#: git-gui.sh:2908 git-gui.sh:3400
+#: git-gui.sh:2917 git-gui.sh:3420
 msgid "Amend Last Commit"
 msgstr ""
 
-#: git-gui.sh:2918 git-gui.sh:3361 lib/remote_branch_delete.tcl:101
+#: git-gui.sh:2927 git-gui.sh:3381 lib/remote_branch_delete.tcl:101
 msgid "Rescan"
 msgstr ""
 
-#: git-gui.sh:2924
+#: git-gui.sh:2933
 msgid "Stage To Commit"
 msgstr ""
 
-#: git-gui.sh:2930
+#: git-gui.sh:2939
 msgid "Stage Changed Files To Commit"
 msgstr ""
 
-#: git-gui.sh:2936
+#: git-gui.sh:2945
 msgid "Unstage From Commit"
 msgstr ""
 
-#: git-gui.sh:2942 lib/index.tcl:521
+#: git-gui.sh:2951 lib/index.tcl:521
 msgid "Revert Changes"
 msgstr ""
 
-#: git-gui.sh:2950 git-gui.sh:3700 git-gui.sh:3731
+#: git-gui.sh:2959 git-gui.sh:3726 git-gui.sh:3757
 msgid "Show Less Context"
 msgstr ""
 
-#: git-gui.sh:2954 git-gui.sh:3704 git-gui.sh:3735
+#: git-gui.sh:2963 git-gui.sh:3730 git-gui.sh:3761
 msgid "Show More Context"
 msgstr ""
 
-#: git-gui.sh:2961 git-gui.sh:3374 git-gui.sh:3485
+#: git-gui.sh:2970 git-gui.sh:3394 git-gui.sh:3511
 msgid "Sign Off"
 msgstr ""
 
-#: git-gui.sh:2977
+#: git-gui.sh:2986
 msgid "Local Merge..."
 msgstr ""
 
-#: git-gui.sh:2982
+#: git-gui.sh:2991
 msgid "Abort Merge..."
 msgstr ""
 
-#: git-gui.sh:2994 git-gui.sh:3022
+#: git-gui.sh:3003 git-gui.sh:3031
 msgid "Add..."
 msgstr ""
 
-#: git-gui.sh:2998
+#: git-gui.sh:3007
 msgid "Push..."
 msgstr ""
 
-#: git-gui.sh:3002
+#: git-gui.sh:3011
 msgid "Delete Branch..."
 msgstr ""
 
-#: git-gui.sh:3012 git-gui.sh:3666
+#: git-gui.sh:3021 git-gui.sh:3692
 msgid "Options..."
 msgstr ""
 
-#: git-gui.sh:3023
+#: git-gui.sh:3032
 msgid "Remove..."
 msgstr ""
 
-#: git-gui.sh:3032 lib/choose_repository.tcl:67
+#: git-gui.sh:3041 lib/choose_repository.tcl:67
 msgid "Help"
 msgstr ""
 
-#: git-gui.sh:3036 git-gui.sh:3040 lib/choose_repository.tcl:61
-#: lib/choose_repository.tcl:70 lib/about.tcl:14
+#: git-gui.sh:3045 git-gui.sh:3049 lib/about.tcl:14
+#: lib/choose_repository.tcl:61 lib/choose_repository.tcl:70
 #, tcl-format
 msgid "About %s"
 msgstr ""
 
-#: git-gui.sh:3064
+#: git-gui.sh:3073
 msgid "Online Documentation"
 msgstr ""
 
-#: git-gui.sh:3067 lib/choose_repository.tcl:64 lib/choose_repository.tcl:73
+#: git-gui.sh:3076 lib/choose_repository.tcl:64 lib/choose_repository.tcl:73
 msgid "Show SSH Key"
 msgstr ""
 
-#: git-gui.sh:3097 git-gui.sh:3229
+#: git-gui.sh:3106 git-gui.sh:3238
 msgid "usage:"
 msgstr ""
 
-#: git-gui.sh:3101 git-gui.sh:3233
+#: git-gui.sh:3110 git-gui.sh:3242
 msgid "Usage"
 msgstr ""
 
-#: git-gui.sh:3182 lib/blame.tcl:575
+#: git-gui.sh:3191 lib/blame.tcl:576
 msgid "Error"
 msgstr ""
 
-#: git-gui.sh:3213
+#: git-gui.sh:3222
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr ""
 
-#: git-gui.sh:3246
+#: git-gui.sh:3255
 msgid "Current Branch:"
 msgstr ""
 
-#: git-gui.sh:3271
+#: git-gui.sh:3280
 msgid "Unstaged Changes"
 msgstr ""
 
-#: git-gui.sh:3293
+#: git-gui.sh:3302
 msgid "Staged Changes (Will Commit)"
 msgstr ""
 
-#: git-gui.sh:3367
+#: git-gui.sh:3387
 msgid "Stage Changed"
 msgstr ""
 
-#: git-gui.sh:3386 lib/transport.tcl:137
+#: git-gui.sh:3406 lib/transport.tcl:137
 msgid "Push"
 msgstr ""
 
-#: git-gui.sh:3413
+#: git-gui.sh:3433
 msgid "Initial Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3414
+#: git-gui.sh:3434
 msgid "Amended Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3415
+#: git-gui.sh:3435
 msgid "Amended Initial Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3416
+#: git-gui.sh:3436
 msgid "Amended Merge Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3417
+#: git-gui.sh:3437
 msgid "Merge Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3418
+#: git-gui.sh:3438
 msgid "Commit Message:"
 msgstr ""
 
-#: git-gui.sh:3477 git-gui.sh:3641 lib/console.tcl:73
+#: git-gui.sh:3503 git-gui.sh:3667 lib/console.tcl:73
 msgid "Copy All"
 msgstr ""
 
-#: git-gui.sh:3501 lib/blame.tcl:106
+#: git-gui.sh:3527 lib/blame.tcl:106
 msgid "File:"
 msgstr ""
 
-#: git-gui.sh:3549 lib/choose_repository.tcl:1100
+#: git-gui.sh:3575 lib/choose_repository.tcl:1079
 msgid "Open"
 msgstr ""
 
-#: git-gui.sh:3629
+#: git-gui.sh:3655
 msgid "Refresh"
 msgstr ""
 
-#: git-gui.sh:3650
+#: git-gui.sh:3676
 msgid "Decrease Font Size"
 msgstr ""
 
-#: git-gui.sh:3654
+#: git-gui.sh:3680
 msgid "Increase Font Size"
 msgstr ""
 
-#: git-gui.sh:3662 lib/blame.tcl:296
+#: git-gui.sh:3688 lib/blame.tcl:296
 msgid "Encoding"
 msgstr ""
 
-#: git-gui.sh:3673
+#: git-gui.sh:3699
 msgid "Apply/Reverse Hunk"
 msgstr ""
 
-#: git-gui.sh:3678
+#: git-gui.sh:3704
 msgid "Apply/Reverse Line"
 msgstr ""
 
-#: git-gui.sh:3684 git-gui.sh:3794 git-gui.sh:3805
+#: git-gui.sh:3710 git-gui.sh:3820 git-gui.sh:3831
 msgid "Revert Hunk"
 msgstr ""
 
-#: git-gui.sh:3689 git-gui.sh:3801 git-gui.sh:3812
+#: git-gui.sh:3715 git-gui.sh:3827 git-gui.sh:3838
 msgid "Revert Line"
 msgstr ""
 
-#: git-gui.sh:3694 git-gui.sh:3791
+#: git-gui.sh:3720 git-gui.sh:3817
 msgid "Undo Last Revert"
 msgstr ""
 
-#: git-gui.sh:3713
+#: git-gui.sh:3739
 msgid "Run Merge Tool"
 msgstr ""
 
-#: git-gui.sh:3718
+#: git-gui.sh:3744
 msgid "Use Remote Version"
 msgstr ""
 
-#: git-gui.sh:3722
+#: git-gui.sh:3748
 msgid "Use Local Version"
 msgstr ""
 
-#: git-gui.sh:3726
+#: git-gui.sh:3752
 msgid "Revert To Base"
 msgstr ""
 
-#: git-gui.sh:3744
+#: git-gui.sh:3770
 msgid "Visualize These Changes In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3748
+#: git-gui.sh:3774
 msgid "Visualize Current Branch History In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3752
+#: git-gui.sh:3778
 msgid "Visualize All Branch History In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3757
+#: git-gui.sh:3783
 msgid "Start git gui In The Submodule"
 msgstr ""
 
-#: git-gui.sh:3793
+#: git-gui.sh:3819
 msgid "Unstage Hunk From Commit"
 msgstr ""
 
-#: git-gui.sh:3797
+#: git-gui.sh:3823
 msgid "Unstage Lines From Commit"
 msgstr ""
 
-#: git-gui.sh:3798 git-gui.sh:3809
+#: git-gui.sh:3824 git-gui.sh:3835
 msgid "Revert Lines"
 msgstr ""
 
-#: git-gui.sh:3800
+#: git-gui.sh:3826
 msgid "Unstage Line From Commit"
 msgstr ""
 
-#: git-gui.sh:3804
+#: git-gui.sh:3830
 msgid "Stage Hunk For Commit"
 msgstr ""
 
-#: git-gui.sh:3808
+#: git-gui.sh:3834
 msgid "Stage Lines For Commit"
 msgstr ""
 
-#: git-gui.sh:3811
+#: git-gui.sh:3837
 msgid "Stage Line For Commit"
 msgstr ""
 
-#: git-gui.sh:3861
+#: git-gui.sh:3887
 msgid "Initializing..."
 msgstr ""
 
-#: git-gui.sh:4017
+#: git-gui.sh:4045
 #, tcl-format
 msgid ""
 "Possible environment issues exist.\n"
@@ -577,14 +577,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: git-gui.sh:4046
+#: git-gui.sh:4074
 msgid ""
 "\n"
 "This is due to a known issue with the\n"
 "Tcl binary distributed by Cygwin."
 msgstr ""
 
-#: git-gui.sh:4051
+#: git-gui.sh:4079
 #, tcl-format
 msgid ""
 "\n"
@@ -595,147 +595,335 @@ msgid ""
 "~/.gitconfig file.\n"
 msgstr ""
 
-#: lib/spellcheck.tcl:57
-msgid "Unsupported spell checker"
+#: lib/about.tcl:26
+msgid "git-gui - a graphical user interface for Git."
 msgstr ""
 
-#: lib/spellcheck.tcl:65
-msgid "Spell checking is unavailable"
-msgstr ""
-
-#: lib/spellcheck.tcl:68
-msgid "Invalid spell checking configuration"
-msgstr ""
-
-#: lib/spellcheck.tcl:70
+#: lib/blame.tcl:74
 #, tcl-format
-msgid "Reverting dictionary to %s."
+msgid "%s (%s): File Viewer"
 msgstr ""
 
-#: lib/spellcheck.tcl:73
-msgid "Spell checker silently failed on startup"
+#: lib/blame.tcl:80
+msgid "Commit:"
 msgstr ""
 
-#: lib/spellcheck.tcl:80
-msgid "Unrecognized spell checker"
+#: lib/blame.tcl:282
+msgid "Copy Commit"
 msgstr ""
 
-#: lib/spellcheck.tcl:186
-msgid "No Suggestions"
+#: lib/blame.tcl:286
+msgid "Find Text..."
 msgstr ""
 
-#: lib/spellcheck.tcl:388
-msgid "Unexpected EOF from spell checker"
+#: lib/blame.tcl:290
+msgid "Goto Line..."
 msgstr ""
 
-#: lib/spellcheck.tcl:392
-msgid "Spell Checker Failed"
+#: lib/blame.tcl:299
+msgid "Do Full Copy Detection"
 msgstr ""
 
-#: lib/transport.tcl:6 lib/remote_add.tcl:132
+#: lib/blame.tcl:303
+msgid "Show History Context"
+msgstr ""
+
+#: lib/blame.tcl:306
+msgid "Blame Parent Commit"
+msgstr ""
+
+#: lib/blame.tcl:469
 #, tcl-format
-msgid "fetch %s"
+msgid "Reading %s..."
 msgstr ""
 
-#: lib/transport.tcl:7
+#: lib/blame.tcl:597
+msgid "Loading copy/move tracking annotations..."
+msgstr ""
+
+#: lib/blame.tcl:614
+msgid "lines annotated"
+msgstr ""
+
+#: lib/blame.tcl:816
+msgid "Loading original location annotations..."
+msgstr ""
+
+#: lib/blame.tcl:819
+msgid "Annotation complete."
+msgstr ""
+
+#: lib/blame.tcl:850
+msgid "Busy"
+msgstr ""
+
+#: lib/blame.tcl:851
+msgid "Annotation process is already running."
+msgstr ""
+
+#: lib/blame.tcl:890
+msgid "Running thorough copy detection..."
+msgstr ""
+
+#: lib/blame.tcl:958
+msgid "Loading annotation..."
+msgstr ""
+
+#: lib/blame.tcl:1011
+msgid "Author:"
+msgstr ""
+
+#: lib/blame.tcl:1015
+msgid "Committer:"
+msgstr ""
+
+#: lib/blame.tcl:1020
+msgid "Original File:"
+msgstr ""
+
+#: lib/blame.tcl:1068
+msgid "Cannot find HEAD commit:"
+msgstr ""
+
+#: lib/blame.tcl:1123
+msgid "Cannot find parent commit:"
+msgstr ""
+
+#: lib/blame.tcl:1138
+msgid "Unable to display parent"
+msgstr ""
+
+#: lib/blame.tcl:1139 lib/diff.tcl:345
+msgid "Error loading diff:"
+msgstr ""
+
+#: lib/blame.tcl:1280
+msgid "Originally By:"
+msgstr ""
+
+#: lib/blame.tcl:1286
+msgid "In File:"
+msgstr ""
+
+#: lib/blame.tcl:1291
+msgid "Copied Or Moved Here By:"
+msgstr ""
+
+#: lib/branch_checkout.tcl:16
 #, tcl-format
-msgid "Fetching new changes from %s"
+msgid "%s (%s): Checkout Branch"
 msgstr ""
 
-#: lib/transport.tcl:18
-#, tcl-format
-msgid "remote prune %s"
+#: lib/branch_checkout.tcl:21
+msgid "Checkout Branch"
 msgstr ""
 
-#: lib/transport.tcl:19
-#, tcl-format
-msgid "Pruning tracking branches deleted from %s"
+#: lib/branch_checkout.tcl:26
+msgid "Checkout"
 msgstr ""
 
-#: lib/transport.tcl:25
-msgid "fetch all remotes"
-msgstr ""
-
-#: lib/transport.tcl:26
-msgid "Fetching new changes from all remotes"
-msgstr ""
-
-#: lib/transport.tcl:40
-msgid "remote prune all remotes"
-msgstr ""
-
-#: lib/transport.tcl:41
-msgid "Pruning tracking branches deleted from all remotes"
-msgstr ""
-
-#: lib/transport.tcl:54 lib/transport.tcl:92 lib/transport.tcl:110
-#: lib/remote_add.tcl:162
-#, tcl-format
-msgid "push %s"
-msgstr ""
-
-#: lib/transport.tcl:55
-#, tcl-format
-msgid "Pushing changes to %s"
-msgstr ""
-
-#: lib/transport.tcl:93
-#, tcl-format
-msgid "Mirroring to %s"
-msgstr ""
-
-#: lib/transport.tcl:111
-#, tcl-format
-msgid "Pushing %s %s to %s"
-msgstr ""
-
-#: lib/transport.tcl:132
-msgid "Push Branches"
-msgstr ""
-
-#: lib/transport.tcl:141 lib/checkout_op.tcl:580 lib/remote_add.tcl:34
-#: lib/browser.tcl:292 lib/branch_checkout.tcl:30 lib/branch_rename.tcl:32
-#: lib/choose_font.tcl:45 lib/option.tcl:127 lib/tools_dlg.tcl:41
-#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/remote_branch_delete.tcl:43
-#: lib/branch_create.tcl:37 lib/branch_delete.tcl:34 lib/merge.tcl:178
+#: lib/branch_checkout.tcl:30 lib/branch_create.tcl:37 lib/branch_delete.tcl:34
+#: lib/branch_rename.tcl:32 lib/browser.tcl:292 lib/checkout_op.tcl:580
+#: lib/choose_font.tcl:45 lib/merge.tcl:178 lib/option.tcl:127
+#: lib/remote_add.tcl:34 lib/remote_branch_delete.tcl:43 lib/tools_dlg.tcl:41
+#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/transport.tcl:141
 msgid "Cancel"
 msgstr ""
 
-#: lib/transport.tcl:147
-msgid "Source Branches"
+#: lib/branch_checkout.tcl:35 lib/browser.tcl:297 lib/tools_dlg.tcl:321
+msgid "Revision"
 msgstr ""
 
-#: lib/transport.tcl:162
-msgid "Destination Repository"
+#: lib/branch_checkout.tcl:39 lib/branch_create.tcl:69 lib/option.tcl:311
+msgid "Options"
 msgstr ""
 
-#: lib/transport.tcl:165 lib/remote_branch_delete.tcl:51
-msgid "Remote:"
+#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
+msgid "Fetch Tracking Branch"
 msgstr ""
 
-#: lib/transport.tcl:187 lib/remote_branch_delete.tcl:72
-msgid "Arbitrary Location:"
+#: lib/branch_checkout.tcl:47
+msgid "Detach From Local Branch"
 msgstr ""
 
-#: lib/transport.tcl:205
-msgid "Transfer Options"
-msgstr ""
-
-#: lib/transport.tcl:207
-msgid "Force overwrite existing branch (may discard changes)"
-msgstr ""
-
-#: lib/transport.tcl:211
-msgid "Use thin pack (for slow network connections)"
-msgstr ""
-
-#: lib/transport.tcl:215
-msgid "Include tags"
-msgstr ""
-
-#: lib/transport.tcl:229
+#: lib/branch_create.tcl:23
 #, tcl-format
-msgid "%s (%s): Push"
+msgid "%s (%s): Create Branch"
+msgstr ""
+
+#: lib/branch_create.tcl:28
+msgid "Create New Branch"
+msgstr ""
+
+#: lib/branch_create.tcl:33 lib/choose_repository.tcl:401
+msgid "Create"
+msgstr ""
+
+#: lib/branch_create.tcl:42
+msgid "Branch Name"
+msgstr ""
+
+#: lib/branch_create.tcl:44 lib/remote_add.tcl:41 lib/tools_dlg.tcl:51
+msgid "Name:"
+msgstr ""
+
+#: lib/branch_create.tcl:57
+msgid "Match Tracking Branch Name"
+msgstr ""
+
+#: lib/branch_create.tcl:66
+msgid "Starting Revision"
+msgstr ""
+
+#: lib/branch_create.tcl:72
+msgid "Update Existing Branch:"
+msgstr ""
+
+#: lib/branch_create.tcl:75
+msgid "No"
+msgstr ""
+
+#: lib/branch_create.tcl:80
+msgid "Fast Forward Only"
+msgstr ""
+
+#: lib/branch_create.tcl:85 lib/checkout_op.tcl:572
+msgid "Reset"
+msgstr ""
+
+#: lib/branch_create.tcl:97
+msgid "Checkout After Creation"
+msgstr ""
+
+#: lib/branch_create.tcl:132
+msgid "Please select a tracking branch."
+msgstr ""
+
+#: lib/branch_create.tcl:141
+#, tcl-format
+msgid "Tracking branch %s is not a branch in the remote repository."
+msgstr ""
+
+#: lib/branch_create.tcl:154 lib/branch_rename.tcl:92
+msgid "Please supply a branch name."
+msgstr ""
+
+#: lib/branch_create.tcl:165 lib/branch_rename.tcl:112
+#, tcl-format
+msgid "'%s' is not an acceptable branch name."
+msgstr ""
+
+#: lib/branch_delete.tcl:16
+#, tcl-format
+msgid "%s (%s): Delete Branch"
+msgstr ""
+
+#: lib/branch_delete.tcl:21
+msgid "Delete Local Branch"
+msgstr ""
+
+#: lib/branch_delete.tcl:39
+msgid "Local Branches"
+msgstr ""
+
+#: lib/branch_delete.tcl:51
+msgid "Delete Only If Merged Into"
+msgstr ""
+
+#: lib/branch_delete.tcl:53 lib/remote_branch_delete.tcl:120
+msgid "Always (Do not perform merge checks)"
+msgstr ""
+
+#: lib/branch_delete.tcl:103
+#, tcl-format
+msgid "The following branches are not completely merged into %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:218
+msgid ""
+"Recovering deleted branches is difficult.\n"
+"\n"
+"Delete the selected branches?"
+msgstr ""
+
+#: lib/branch_delete.tcl:131
+#, tcl-format
+msgid " - %s:"
+msgstr ""
+
+#: lib/branch_delete.tcl:141
+#, tcl-format
+msgid ""
+"Failed to delete branches:\n"
+"%s"
+msgstr ""
+
+#: lib/branch_rename.tcl:15
+#, tcl-format
+msgid "%s (%s): Rename Branch"
+msgstr ""
+
+#: lib/branch_rename.tcl:23
+msgid "Rename Branch"
+msgstr ""
+
+#: lib/branch_rename.tcl:28
+msgid "Rename"
+msgstr ""
+
+#: lib/branch_rename.tcl:38
+msgid "Branch:"
+msgstr ""
+
+#: lib/branch_rename.tcl:46
+msgid "New Name:"
+msgstr ""
+
+#: lib/branch_rename.tcl:81
+msgid "Please select a branch to rename."
+msgstr ""
+
+#: lib/branch_rename.tcl:102 lib/checkout_op.tcl:202
+#, tcl-format
+msgid "Branch '%s' already exists."
+msgstr ""
+
+#: lib/branch_rename.tcl:123
+#, tcl-format
+msgid "Failed to rename '%s'."
+msgstr ""
+
+#: lib/browser.tcl:17
+msgid "Starting..."
+msgstr ""
+
+#: lib/browser.tcl:27
+#, tcl-format
+msgid "%s (%s): File Browser"
+msgstr ""
+
+#: lib/browser.tcl:132 lib/browser.tcl:149
+#, tcl-format
+msgid "Loading %s..."
+msgstr ""
+
+#: lib/browser.tcl:193
+msgid "[Up To Parent]"
+msgstr ""
+
+#: lib/browser.tcl:275
+#, tcl-format
+msgid "%s (%s): Browse Branch Files"
+msgstr ""
+
+#: lib/browser.tcl:282
+msgid "Browse Branch Files"
+msgstr ""
+
+#: lib/browser.tcl:288 lib/choose_repository.tcl:416
+#: lib/choose_repository.tcl:503 lib/choose_repository.tcl:512
+#: lib/choose_repository.tcl:1094
+msgid "Browse"
 msgstr ""
 
 #: lib/checkout_op.tcl:85
@@ -748,8 +936,8 @@ msgstr ""
 msgid "fatal: Cannot resolve %s"
 msgstr ""
 
-#: lib/checkout_op.tcl:146 lib/sshkey.tcl:58 lib/console.tcl:81
-#: lib/database.tcl:30
+#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:30
+#: lib/sshkey.tcl:58
 msgid "Close"
 msgstr ""
 
@@ -761,11 +949,6 @@ msgstr ""
 #: lib/checkout_op.tcl:194
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
-msgstr ""
-
-#: lib/checkout_op.tcl:202 lib/branch_rename.tcl:102
-#, tcl-format
-msgid "Branch '%s' already exists."
 msgstr ""
 
 #: lib/checkout_op.tcl:229
@@ -851,12 +1034,8 @@ msgstr ""
 msgid "Reset '%s'?"
 msgstr ""
 
-#: lib/checkout_op.tcl:568 lib/tools_dlg.tcl:336 lib/merge.tcl:170
+#: lib/checkout_op.tcl:568 lib/merge.tcl:170 lib/tools_dlg.tcl:336
 msgid "Visualize"
-msgstr ""
-
-#: lib/checkout_op.tcl:572 lib/branch_create.tcl:85
-msgid "Reset"
 msgstr ""
 
 #: lib/checkout_op.tcl:636
@@ -868,323 +1047,6 @@ msgid ""
 "your files, but failed to update an internal Git file.\n"
 "\n"
 "This should not have occurred.  %s will now close and give up."
-msgstr ""
-
-#: lib/remote_add.tcl:20
-#, tcl-format
-msgid "%s (%s): Add Remote"
-msgstr ""
-
-#: lib/remote_add.tcl:25
-msgid "Add New Remote"
-msgstr ""
-
-#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
-msgid "Add"
-msgstr ""
-
-#: lib/remote_add.tcl:39
-msgid "Remote Details"
-msgstr ""
-
-#: lib/remote_add.tcl:41 lib/tools_dlg.tcl:51 lib/branch_create.tcl:44
-msgid "Name:"
-msgstr ""
-
-#: lib/remote_add.tcl:50
-msgid "Location:"
-msgstr ""
-
-#: lib/remote_add.tcl:60
-msgid "Further Action"
-msgstr ""
-
-#: lib/remote_add.tcl:63
-msgid "Fetch Immediately"
-msgstr ""
-
-#: lib/remote_add.tcl:69
-msgid "Initialize Remote Repository and Push"
-msgstr ""
-
-#: lib/remote_add.tcl:75
-msgid "Do Nothing Else Now"
-msgstr ""
-
-#: lib/remote_add.tcl:100
-msgid "Please supply a remote name."
-msgstr ""
-
-#: lib/remote_add.tcl:113
-#, tcl-format
-msgid "'%s' is not an acceptable remote name."
-msgstr ""
-
-#: lib/remote_add.tcl:124
-#, tcl-format
-msgid "Failed to add remote '%s' of location '%s'."
-msgstr ""
-
-#: lib/remote_add.tcl:133
-#, tcl-format
-msgid "Fetching the %s"
-msgstr ""
-
-#: lib/remote_add.tcl:156
-#, tcl-format
-msgid "Do not know how to initialize repository at location '%s'."
-msgstr ""
-
-#: lib/remote_add.tcl:163
-#, tcl-format
-msgid "Setting up the %s (at %s)"
-msgstr ""
-
-#: lib/browser.tcl:17
-msgid "Starting..."
-msgstr ""
-
-#: lib/browser.tcl:27
-#, tcl-format
-msgid "%s (%s): File Browser"
-msgstr ""
-
-#: lib/browser.tcl:132 lib/browser.tcl:149
-#, tcl-format
-msgid "Loading %s..."
-msgstr ""
-
-#: lib/browser.tcl:193
-msgid "[Up To Parent]"
-msgstr ""
-
-#: lib/browser.tcl:275
-#, tcl-format
-msgid "%s (%s): Browse Branch Files"
-msgstr ""
-
-#: lib/browser.tcl:282
-msgid "Browse Branch Files"
-msgstr ""
-
-#: lib/browser.tcl:288 lib/choose_repository.tcl:437
-#: lib/choose_repository.tcl:524 lib/choose_repository.tcl:533
-#: lib/choose_repository.tcl:1115
-msgid "Browse"
-msgstr ""
-
-#: lib/browser.tcl:297 lib/branch_checkout.tcl:35 lib/tools_dlg.tcl:321
-msgid "Revision"
-msgstr ""
-
-#: lib/index.tcl:6
-msgid "Unable to unlock the index."
-msgstr ""
-
-#: lib/index.tcl:30
-msgid "Index Error"
-msgstr ""
-
-#: lib/index.tcl:32
-msgid ""
-"Updating the Git index failed.  A rescan will be automatically started to "
-"resynchronize git-gui."
-msgstr ""
-
-#: lib/index.tcl:43
-msgid "Continue"
-msgstr ""
-
-#: lib/index.tcl:46
-msgid "Unlock Index"
-msgstr ""
-
-#: lib/index.tcl:77 lib/index.tcl:146 lib/index.tcl:220 lib/index.tcl:587
-#: lib/choose_repository.tcl:999
-msgid "files"
-msgstr ""
-
-#: lib/index.tcl:326
-msgid "Unstaging selected files from commit"
-msgstr ""
-
-#: lib/index.tcl:330
-#, tcl-format
-msgid "Unstaging %s from commit"
-msgstr ""
-
-#: lib/index.tcl:369
-msgid "Ready to commit."
-msgstr ""
-
-#: lib/index.tcl:378
-msgid "Adding selected files"
-msgstr ""
-
-#: lib/index.tcl:382
-#, tcl-format
-msgid "Adding %s"
-msgstr ""
-
-#: lib/index.tcl:412
-#, tcl-format
-msgid "Stage %d untracked files?"
-msgstr ""
-
-#: lib/index.tcl:420
-msgid "Adding all changed files"
-msgstr ""
-
-#: lib/index.tcl:503
-#, tcl-format
-msgid "Revert changes in file %s?"
-msgstr ""
-
-#: lib/index.tcl:508
-#, tcl-format
-msgid "Revert changes in these %i files?"
-msgstr ""
-
-#: lib/index.tcl:517
-msgid "Any unstaged changes will be permanently lost by the revert."
-msgstr ""
-
-#: lib/index.tcl:520 lib/index.tcl:563
-msgid "Do Nothing"
-msgstr ""
-
-#: lib/index.tcl:545
-#, tcl-format
-msgid "Delete untracked file %s?"
-msgstr ""
-
-#: lib/index.tcl:550
-#, tcl-format
-msgid "Delete these %i untracked files?"
-msgstr ""
-
-#: lib/index.tcl:560
-msgid "Files will be permanently deleted."
-msgstr ""
-
-#: lib/index.tcl:564
-msgid "Delete Files"
-msgstr ""
-
-#: lib/index.tcl:586
-msgid "Deleting"
-msgstr ""
-
-#: lib/index.tcl:665
-msgid "Encountered errors deleting files:\n"
-msgstr ""
-
-#: lib/index.tcl:674
-#, tcl-format
-msgid "None of the %d selected files could be deleted."
-msgstr ""
-
-#: lib/index.tcl:679
-#, tcl-format
-msgid "%d of the %d selected files could not be deleted."
-msgstr ""
-
-#: lib/index.tcl:726
-msgid "Reverting selected files"
-msgstr ""
-
-#: lib/index.tcl:730
-#, tcl-format
-msgid "Reverting %s"
-msgstr ""
-
-#: lib/branch_checkout.tcl:16
-#, tcl-format
-msgid "%s (%s): Checkout Branch"
-msgstr ""
-
-#: lib/branch_checkout.tcl:21
-msgid "Checkout Branch"
-msgstr ""
-
-#: lib/branch_checkout.tcl:26
-msgid "Checkout"
-msgstr ""
-
-#: lib/branch_checkout.tcl:39 lib/option.tcl:310 lib/branch_create.tcl:69
-msgid "Options"
-msgstr ""
-
-#: lib/branch_checkout.tcl:42 lib/branch_create.tcl:92
-msgid "Fetch Tracking Branch"
-msgstr ""
-
-#: lib/branch_checkout.tcl:47
-msgid "Detach From Local Branch"
-msgstr ""
-
-#: lib/status_bar.tcl:263
-#, tcl-format
-msgid "%s ... %*i of %*i %s (%3i%%)"
-msgstr ""
-
-#: lib/remote.tcl:200
-msgid "Push to"
-msgstr ""
-
-#: lib/remote.tcl:218
-msgid "Remove Remote"
-msgstr ""
-
-#: lib/remote.tcl:223
-msgid "Prune from"
-msgstr ""
-
-#: lib/remote.tcl:228
-msgid "Fetch from"
-msgstr ""
-
-#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
-msgid "All"
-msgstr ""
-
-#: lib/branch_rename.tcl:15
-#, tcl-format
-msgid "%s (%s): Rename Branch"
-msgstr ""
-
-#: lib/branch_rename.tcl:23
-msgid "Rename Branch"
-msgstr ""
-
-#: lib/branch_rename.tcl:28
-msgid "Rename"
-msgstr ""
-
-#: lib/branch_rename.tcl:38
-msgid "Branch:"
-msgstr ""
-
-#: lib/branch_rename.tcl:46
-msgid "New Name:"
-msgstr ""
-
-#: lib/branch_rename.tcl:81
-msgid "Please select a branch to rename."
-msgstr ""
-
-#: lib/branch_rename.tcl:92 lib/branch_create.tcl:154
-msgid "Please supply a branch name."
-msgstr ""
-
-#: lib/branch_rename.tcl:112 lib/branch_create.tcl:165
-#, tcl-format
-msgid "'%s' is not an acceptable branch name."
-msgstr ""
-
-#: lib/branch_rename.tcl:123
-#, tcl-format
-msgid "Failed to rename '%s'."
 msgstr ""
 
 #: lib/choose_font.tcl:41
@@ -1209,492 +1071,11 @@ msgid ""
 "If you like this text, it can be your font."
 msgstr ""
 
-#: lib/option.tcl:11
-#, tcl-format
-msgid "Invalid global encoding '%s'"
-msgstr ""
-
-#: lib/option.tcl:19
-#, tcl-format
-msgid "Invalid repo encoding '%s'"
-msgstr ""
-
-#: lib/option.tcl:119
-msgid "Restore Defaults"
-msgstr ""
-
-#: lib/option.tcl:123
-msgid "Save"
-msgstr ""
-
-#: lib/option.tcl:133
-#, tcl-format
-msgid "%s Repository"
-msgstr ""
-
-#: lib/option.tcl:134
-msgid "Global (All Repositories)"
-msgstr ""
-
-#: lib/option.tcl:140
-msgid "User Name"
-msgstr ""
-
-#: lib/option.tcl:141
-msgid "Email Address"
-msgstr ""
-
-#: lib/option.tcl:143
-msgid "Summarize Merge Commits"
-msgstr ""
-
-#: lib/option.tcl:144
-msgid "Merge Verbosity"
-msgstr ""
-
-#: lib/option.tcl:145
-msgid "Show Diffstat After Merge"
-msgstr ""
-
-#: lib/option.tcl:146
-msgid "Use Merge Tool"
-msgstr ""
-
-#: lib/option.tcl:148
-msgid "Trust File Modification Timestamps"
-msgstr ""
-
-#: lib/option.tcl:149
-msgid "Prune Tracking Branches During Fetch"
-msgstr ""
-
-#: lib/option.tcl:150
-msgid "Match Tracking Branches"
-msgstr ""
-
-#: lib/option.tcl:151
-msgid "Use Textconv For Diffs and Blames"
-msgstr ""
-
-#: lib/option.tcl:152
-msgid "Blame Copy Only On Changed Files"
-msgstr ""
-
-#: lib/option.tcl:153
-msgid "Maximum Length of Recent Repositories List"
-msgstr ""
-
-#: lib/option.tcl:154
-msgid "Minimum Letters To Blame Copy On"
-msgstr ""
-
-#: lib/option.tcl:155
-msgid "Blame History Context Radius (days)"
-msgstr ""
-
-#: lib/option.tcl:156
-msgid "Number of Diff Context Lines"
-msgstr ""
-
-#: lib/option.tcl:157
-msgid "Additional Diff Parameters"
-msgstr ""
-
-#: lib/option.tcl:158
-msgid "Commit Message Text Width"
-msgstr ""
-
-#: lib/option.tcl:159
-msgid "New Branch Name Template"
-msgstr ""
-
-#: lib/option.tcl:160
-msgid "Default File Contents Encoding"
-msgstr ""
-
-#: lib/option.tcl:161
-msgid "Warn before committing to a detached head"
-msgstr ""
-
-#: lib/option.tcl:162
-msgid "Staging of untracked files"
-msgstr ""
-
-#: lib/option.tcl:163
-msgid "Show untracked files"
-msgstr ""
-
-#: lib/option.tcl:164
-msgid "Tab spacing"
-msgstr ""
-
-#: lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220 lib/option.tcl:282
-#: lib/database.tcl:57
-#, tcl-format
-msgid "%s:"
-msgstr ""
-
-#: lib/option.tcl:210
-msgid "Change"
-msgstr ""
-
-#: lib/option.tcl:254
-msgid "Spelling Dictionary:"
-msgstr ""
-
-#: lib/option.tcl:284
-msgid "Change Font"
-msgstr ""
-
-#: lib/option.tcl:288
-#, tcl-format
-msgid "Choose %s"
-msgstr ""
-
-#: lib/option.tcl:294
-msgid "pt."
-msgstr ""
-
-#: lib/option.tcl:308
-msgid "Preferences"
-msgstr ""
-
-#: lib/option.tcl:345
-msgid "Failed to completely save options:"
-msgstr ""
-
-#: lib/encoding.tcl:443
-msgid "Default"
-msgstr ""
-
-#: lib/encoding.tcl:448
-#, tcl-format
-msgid "System (%s)"
-msgstr ""
-
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
-msgid "Other"
-msgstr ""
-
-#: lib/tools.tcl:76
-#, tcl-format
-msgid "Running %s requires a selected file."
-msgstr ""
-
-#: lib/tools.tcl:92
-#, tcl-format
-msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
-msgstr ""
-
-#: lib/tools.tcl:96
-#, tcl-format
-msgid "Are you sure you want to run %s?"
-msgstr ""
-
-#: lib/tools.tcl:118
-#, tcl-format
-msgid "Tool: %s"
-msgstr ""
-
-#: lib/tools.tcl:119
-#, tcl-format
-msgid "Running: %s"
-msgstr ""
-
-#: lib/tools.tcl:158
-#, tcl-format
-msgid "Tool completed successfully: %s"
-msgstr ""
-
-#: lib/tools.tcl:160
-#, tcl-format
-msgid "Tool failed: %s"
-msgstr ""
-
-#: lib/mergetool.tcl:8
-msgid "Force resolution to the base version?"
-msgstr ""
-
-#: lib/mergetool.tcl:9
-msgid "Force resolution to this branch?"
-msgstr ""
-
-#: lib/mergetool.tcl:10
-msgid "Force resolution to the other branch?"
-msgstr ""
-
-#: lib/mergetool.tcl:14
-#, tcl-format
-msgid ""
-"Note that the diff shows only conflicting changes.\n"
-"\n"
-"%s will be overwritten.\n"
-"\n"
-"This operation can be undone only by restarting the merge."
-msgstr ""
-
-#: lib/mergetool.tcl:45
-#, tcl-format
-msgid "File %s seems to have unresolved conflicts, still stage?"
-msgstr ""
-
-#: lib/mergetool.tcl:60
-#, tcl-format
-msgid "Adding resolution for %s"
-msgstr ""
-
-#: lib/mergetool.tcl:141
-msgid "Cannot resolve deletion or link conflicts using a tool"
-msgstr ""
-
-#: lib/mergetool.tcl:146
-msgid "Conflict file does not exist"
-msgstr ""
-
-#: lib/mergetool.tcl:246
-#, tcl-format
-msgid "Not a GUI merge tool: '%s'"
-msgstr ""
-
-#: lib/mergetool.tcl:275
-#, tcl-format
-msgid "Unsupported merge tool '%s'"
-msgstr ""
-
-#: lib/mergetool.tcl:310
-msgid "Merge tool is already running, terminate it?"
-msgstr ""
-
-#: lib/mergetool.tcl:330
-#, tcl-format
-msgid ""
-"Error retrieving versions:\n"
-"%s"
-msgstr ""
-
-#: lib/mergetool.tcl:350
-#, tcl-format
-msgid ""
-"Could not start the merge tool:\n"
-"\n"
-"%s"
-msgstr ""
-
-#: lib/mergetool.tcl:354
-msgid "Running merge tool..."
-msgstr ""
-
-#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
-msgid "Merge tool failed."
-msgstr ""
-
-#: lib/tools_dlg.tcl:22
-#, tcl-format
-msgid "%s (%s): Add Tool"
-msgstr ""
-
-#: lib/tools_dlg.tcl:28
-msgid "Add New Tool Command"
-msgstr ""
-
-#: lib/tools_dlg.tcl:34
-msgid "Add globally"
-msgstr ""
-
-#: lib/tools_dlg.tcl:46
-msgid "Tool Details"
-msgstr ""
-
-#: lib/tools_dlg.tcl:49
-msgid "Use '/' separators to create a submenu tree:"
-msgstr ""
-
-#: lib/tools_dlg.tcl:60
-msgid "Command:"
-msgstr ""
-
-#: lib/tools_dlg.tcl:71
-msgid "Show a dialog before running"
-msgstr ""
-
-#: lib/tools_dlg.tcl:77
-msgid "Ask the user to select a revision (sets $REVISION)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:82
-msgid "Ask the user for additional arguments (sets $ARGS)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:89
-msgid "Don't show the command output window"
-msgstr ""
-
-#: lib/tools_dlg.tcl:94
-msgid "Run only if a diff is selected ($FILENAME not empty)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:118
-msgid "Please supply a name for the tool."
-msgstr ""
-
-#: lib/tools_dlg.tcl:126
-#, tcl-format
-msgid "Tool '%s' already exists."
-msgstr ""
-
-#: lib/tools_dlg.tcl:148
-#, tcl-format
-msgid ""
-"Could not add tool:\n"
-"%s"
-msgstr ""
-
-#: lib/tools_dlg.tcl:187
-#, tcl-format
-msgid "%s (%s): Remove Tool"
-msgstr ""
-
-#: lib/tools_dlg.tcl:193
-msgid "Remove Tool Commands"
-msgstr ""
-
-#: lib/tools_dlg.tcl:198
-msgid "Remove"
-msgstr ""
-
-#: lib/tools_dlg.tcl:231
-msgid "(Blue denotes repository-local tools)"
-msgstr ""
-
-#: lib/tools_dlg.tcl:283
-#, tcl-format
-msgid "%s (%s):"
-msgstr ""
-
-#: lib/tools_dlg.tcl:292
-#, tcl-format
-msgid "Run Command: %s"
-msgstr ""
-
-#: lib/tools_dlg.tcl:306
-msgid "Arguments"
-msgstr ""
-
-#: lib/tools_dlg.tcl:341
-msgid "OK"
-msgstr ""
-
-#: lib/search.tcl:48
-msgid "Find:"
-msgstr ""
-
-#: lib/search.tcl:50
-msgid "Next"
-msgstr ""
-
-#: lib/search.tcl:51
-msgid "Prev"
-msgstr ""
-
-#: lib/search.tcl:52
-msgid "RegExp"
-msgstr ""
-
-#: lib/search.tcl:54
-msgid "Case"
-msgstr ""
-
-#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
-#, tcl-format
-msgid "%s (%s): Create Desktop Icon"
-msgstr ""
-
-#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
-msgid "Cannot write shortcut:"
-msgstr ""
-
-#: lib/shortcut.tcl:140
-msgid "Cannot write icon:"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:29
-#, tcl-format
-msgid "%s (%s): Delete Branch Remotely"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:34
-msgid "Delete Branch Remotely"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:48
-msgid "From Repository"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:88
-msgid "Branches"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:110
-msgid "Delete Only If"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:112
-msgid "Merged Into:"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:120 lib/branch_delete.tcl:53
-msgid "Always (Do not perform merge checks)"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:153
-msgid "A branch is required for 'Merged Into'."
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:185
-#, tcl-format
-msgid ""
-"The following branches are not completely merged into %s:\n"
-"\n"
-" - %s"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:190
-#, tcl-format
-msgid ""
-"One or more of the merge tests failed because you have not fetched the "
-"necessary commits.  Try fetching from %s first."
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:208
-msgid "Please select one or more branches to delete."
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:218 lib/branch_delete.tcl:115
-msgid ""
-"Recovering deleted branches is difficult.\n"
-"\n"
-"Delete the selected branches?"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:227
-#, tcl-format
-msgid "Deleting branches from %s"
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:300
-msgid "No repository selected."
-msgstr ""
-
-#: lib/remote_branch_delete.tcl:305
-#, tcl-format
-msgid "Scanning %s..."
-msgstr ""
-
 #: lib/choose_repository.tcl:45
 msgid "Git Gui"
 msgstr ""
 
-#: lib/choose_repository.tcl:104 lib/choose_repository.tcl:427
+#: lib/choose_repository.tcl:104 lib/choose_repository.tcl:406
 msgid "Create New Repository"
 msgstr ""
 
@@ -1702,7 +1083,7 @@ msgstr ""
 msgid "New..."
 msgstr ""
 
-#: lib/choose_repository.tcl:117 lib/choose_repository.tcl:511
+#: lib/choose_repository.tcl:117 lib/choose_repository.tcl:490
 msgid "Clone Existing Repository"
 msgstr ""
 
@@ -1710,7 +1091,7 @@ msgstr ""
 msgid "Clone..."
 msgstr ""
 
-#: lib/choose_repository.tcl:135 lib/choose_repository.tcl:1105
+#: lib/choose_repository.tcl:135 lib/choose_repository.tcl:1084
 msgid "Open Existing Repository"
 msgstr ""
 
@@ -1732,521 +1113,197 @@ msgstr ""
 msgid "Failed to create repository %s:"
 msgstr ""
 
-#: lib/choose_repository.tcl:422 lib/branch_create.tcl:33
-msgid "Create"
-msgstr ""
-
-#: lib/choose_repository.tcl:432
+#: lib/choose_repository.tcl:411
 msgid "Directory:"
 msgstr ""
 
-#: lib/choose_repository.tcl:462 lib/choose_repository.tcl:588
-#: lib/choose_repository.tcl:1139
+#: lib/choose_repository.tcl:441 lib/choose_repository.tcl:567
+#: lib/choose_repository.tcl:1118
 msgid "Git Repository"
 msgstr ""
 
-#: lib/choose_repository.tcl:487
+#: lib/choose_repository.tcl:466
 #, tcl-format
 msgid "Directory %s already exists."
 msgstr ""
 
-#: lib/choose_repository.tcl:491
+#: lib/choose_repository.tcl:470
 #, tcl-format
 msgid "File %s already exists."
 msgstr ""
 
-#: lib/choose_repository.tcl:506
+#: lib/choose_repository.tcl:485
 msgid "Clone"
 msgstr ""
 
-#: lib/choose_repository.tcl:519
+#: lib/choose_repository.tcl:498
 msgid "Source Location:"
 msgstr ""
 
-#: lib/choose_repository.tcl:528
+#: lib/choose_repository.tcl:507
 msgid "Target Directory:"
 msgstr ""
 
-#: lib/choose_repository.tcl:538
+#: lib/choose_repository.tcl:517
 msgid "Clone Type:"
 msgstr ""
 
-#: lib/choose_repository.tcl:543
+#: lib/choose_repository.tcl:522
 msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
 msgstr ""
 
-#: lib/choose_repository.tcl:548
+#: lib/choose_repository.tcl:527
 msgid "Full Copy (Slower, Redundant Backup)"
 msgstr ""
 
-#: lib/choose_repository.tcl:553
+#: lib/choose_repository.tcl:532
 msgid "Shared (Fastest, Not Recommended, No Backup)"
 msgstr ""
 
-#: lib/choose_repository.tcl:560
+#: lib/choose_repository.tcl:539
 msgid "Recursively clone submodules too"
 msgstr ""
 
-#: lib/choose_repository.tcl:594 lib/choose_repository.tcl:641
-#: lib/choose_repository.tcl:790 lib/choose_repository.tcl:864
-#: lib/choose_repository.tcl:1145 lib/choose_repository.tcl:1153
+#: lib/choose_repository.tcl:573 lib/choose_repository.tcl:620
+#: lib/choose_repository.tcl:769 lib/choose_repository.tcl:843
+#: lib/choose_repository.tcl:1124 lib/choose_repository.tcl:1132
 #, tcl-format
 msgid "Not a Git repository: %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:630
+#: lib/choose_repository.tcl:609
 msgid "Standard only available for local repository."
 msgstr ""
 
-#: lib/choose_repository.tcl:634
+#: lib/choose_repository.tcl:613
 msgid "Shared only available for local repository."
 msgstr ""
 
-#: lib/choose_repository.tcl:655
+#: lib/choose_repository.tcl:634
 #, tcl-format
 msgid "Location %s already exists."
 msgstr ""
 
-#: lib/choose_repository.tcl:666
+#: lib/choose_repository.tcl:645
 msgid "Failed to configure origin"
 msgstr ""
 
-#: lib/choose_repository.tcl:678
+#: lib/choose_repository.tcl:657
 msgid "Counting objects"
 msgstr ""
 
-#: lib/choose_repository.tcl:679
+#: lib/choose_repository.tcl:658
 msgid "buckets"
 msgstr ""
 
-#: lib/choose_repository.tcl:703
+#: lib/choose_repository.tcl:682
 #, tcl-format
 msgid "Unable to copy objects/info/alternates: %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:740
+#: lib/choose_repository.tcl:719
 #, tcl-format
 msgid "Nothing to clone from %s."
 msgstr ""
 
-#: lib/choose_repository.tcl:742 lib/choose_repository.tcl:962
-#: lib/choose_repository.tcl:974
+#: lib/choose_repository.tcl:721 lib/choose_repository.tcl:941
+#: lib/choose_repository.tcl:953
 msgid "The 'master' branch has not been initialized."
 msgstr ""
 
-#: lib/choose_repository.tcl:755
+#: lib/choose_repository.tcl:734
 msgid "Hardlinks are unavailable.  Falling back to copying."
 msgstr ""
 
-#: lib/choose_repository.tcl:769
+#: lib/choose_repository.tcl:748
 #, tcl-format
 msgid "Cloning from %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:800
+#: lib/choose_repository.tcl:779
 msgid "Copying objects"
 msgstr ""
 
-#: lib/choose_repository.tcl:801
+#: lib/choose_repository.tcl:780
 msgid "KiB"
 msgstr ""
 
-#: lib/choose_repository.tcl:825
+#: lib/choose_repository.tcl:804
 #, tcl-format
 msgid "Unable to copy object: %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:837
+#: lib/choose_repository.tcl:816
 msgid "Linking objects"
 msgstr ""
 
-#: lib/choose_repository.tcl:838
+#: lib/choose_repository.tcl:817
 msgid "objects"
 msgstr ""
 
-#: lib/choose_repository.tcl:846
+#: lib/choose_repository.tcl:825
 #, tcl-format
 msgid "Unable to hardlink object: %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:903
+#: lib/choose_repository.tcl:882
 msgid "Cannot fetch branches and objects.  See console output for details."
 msgstr ""
 
-#: lib/choose_repository.tcl:914
+#: lib/choose_repository.tcl:893
 msgid "Cannot fetch tags.  See console output for details."
 msgstr ""
 
-#: lib/choose_repository.tcl:938
+#: lib/choose_repository.tcl:917
 msgid "Cannot determine HEAD.  See console output for details."
 msgstr ""
 
-#: lib/choose_repository.tcl:947
+#: lib/choose_repository.tcl:926
 #, tcl-format
 msgid "Unable to cleanup %s"
 msgstr ""
 
-#: lib/choose_repository.tcl:953
+#: lib/choose_repository.tcl:932
 msgid "Clone failed."
 msgstr ""
 
-#: lib/choose_repository.tcl:960
+#: lib/choose_repository.tcl:939
 msgid "No default branch obtained."
 msgstr ""
 
-#: lib/choose_repository.tcl:971
+#: lib/choose_repository.tcl:950
 #, tcl-format
 msgid "Cannot resolve %s as a commit."
 msgstr ""
 
-#: lib/choose_repository.tcl:998
+#: lib/choose_repository.tcl:977
 msgid "Creating working directory"
 msgstr ""
 
-#: lib/choose_repository.tcl:1028
+#: lib/choose_repository.tcl:978 lib/index.tcl:77 lib/index.tcl:146
+#: lib/index.tcl:220 lib/index.tcl:589
+msgid "files"
+msgstr ""
+
+#: lib/choose_repository.tcl:1007
 msgid "Initial file checkout failed."
 msgstr ""
 
-#: lib/choose_repository.tcl:1072
+#: lib/choose_repository.tcl:1051
 msgid "Cloning submodules"
 msgstr ""
 
-#: lib/choose_repository.tcl:1087
+#: lib/choose_repository.tcl:1066
 msgid "Cannot clone submodules."
 msgstr ""
 
-#: lib/choose_repository.tcl:1110
+#: lib/choose_repository.tcl:1089
 msgid "Repository:"
 msgstr ""
 
-#: lib/choose_repository.tcl:1159
+#: lib/choose_repository.tcl:1138
 #, tcl-format
 msgid "Failed to open repository %s:"
-msgstr ""
-
-#: lib/about.tcl:26
-msgid "git-gui - a graphical user interface for Git."
-msgstr ""
-
-#: lib/blame.tcl:74
-#, tcl-format
-msgid "%s (%s): File Viewer"
-msgstr ""
-
-#: lib/blame.tcl:80
-msgid "Commit:"
-msgstr ""
-
-#: lib/blame.tcl:282
-msgid "Copy Commit"
-msgstr ""
-
-#: lib/blame.tcl:286
-msgid "Find Text..."
-msgstr ""
-
-#: lib/blame.tcl:290
-msgid "Goto Line..."
-msgstr ""
-
-#: lib/blame.tcl:299
-msgid "Do Full Copy Detection"
-msgstr ""
-
-#: lib/blame.tcl:303
-msgid "Show History Context"
-msgstr ""
-
-#: lib/blame.tcl:306
-msgid "Blame Parent Commit"
-msgstr ""
-
-#: lib/blame.tcl:468
-#, tcl-format
-msgid "Reading %s..."
-msgstr ""
-
-#: lib/blame.tcl:596
-msgid "Loading copy/move tracking annotations..."
-msgstr ""
-
-#: lib/blame.tcl:613
-msgid "lines annotated"
-msgstr ""
-
-#: lib/blame.tcl:815
-msgid "Loading original location annotations..."
-msgstr ""
-
-#: lib/blame.tcl:818
-msgid "Annotation complete."
-msgstr ""
-
-#: lib/blame.tcl:849
-msgid "Busy"
-msgstr ""
-
-#: lib/blame.tcl:850
-msgid "Annotation process is already running."
-msgstr ""
-
-#: lib/blame.tcl:889
-msgid "Running thorough copy detection..."
-msgstr ""
-
-#: lib/blame.tcl:957
-msgid "Loading annotation..."
-msgstr ""
-
-#: lib/blame.tcl:1010
-msgid "Author:"
-msgstr ""
-
-#: lib/blame.tcl:1014
-msgid "Committer:"
-msgstr ""
-
-#: lib/blame.tcl:1019
-msgid "Original File:"
-msgstr ""
-
-#: lib/blame.tcl:1067
-msgid "Cannot find HEAD commit:"
-msgstr ""
-
-#: lib/blame.tcl:1122
-msgid "Cannot find parent commit:"
-msgstr ""
-
-#: lib/blame.tcl:1137
-msgid "Unable to display parent"
-msgstr ""
-
-#: lib/blame.tcl:1138 lib/diff.tcl:345
-msgid "Error loading diff:"
-msgstr ""
-
-#: lib/blame.tcl:1279
-msgid "Originally By:"
-msgstr ""
-
-#: lib/blame.tcl:1285
-msgid "In File:"
-msgstr ""
-
-#: lib/blame.tcl:1290
-msgid "Copied Or Moved Here By:"
-msgstr ""
-
-#: lib/diff.tcl:77
-#, tcl-format
-msgid ""
-"No differences detected.\n"
-"\n"
-"%s has no changes.\n"
-"\n"
-"The modification date of this file was updated by another application, but "
-"the content within the file was not changed.\n"
-"\n"
-"A rescan will be automatically started to find other files which may have "
-"the same state."
-msgstr ""
-
-#: lib/diff.tcl:117
-#, tcl-format
-msgid "Loading diff of %s..."
-msgstr ""
-
-#: lib/diff.tcl:143
-msgid ""
-"LOCAL: deleted\n"
-"REMOTE:\n"
-msgstr ""
-
-#: lib/diff.tcl:148
-msgid ""
-"REMOTE: deleted\n"
-"LOCAL:\n"
-msgstr ""
-
-#: lib/diff.tcl:155
-msgid "LOCAL:\n"
-msgstr ""
-
-#: lib/diff.tcl:158
-msgid "REMOTE:\n"
-msgstr ""
-
-#: lib/diff.tcl:220 lib/diff.tcl:344
-#, tcl-format
-msgid "Unable to display %s"
-msgstr ""
-
-#: lib/diff.tcl:221
-msgid "Error loading file:"
-msgstr ""
-
-#: lib/diff.tcl:227
-msgid "Git Repository (subproject)"
-msgstr ""
-
-#: lib/diff.tcl:239
-msgid "* Binary file (not showing content)."
-msgstr ""
-
-#: lib/diff.tcl:244
-#, tcl-format
-msgid ""
-"* Untracked file is %d bytes.\n"
-"* Showing only first %d bytes.\n"
-msgstr ""
-
-#: lib/diff.tcl:250
-#, tcl-format
-msgid ""
-"\n"
-"* Untracked file clipped here by %s.\n"
-"* To see the entire file, use an external editor.\n"
-msgstr ""
-
-#: lib/diff.tcl:583
-msgid "Failed to unstage selected hunk."
-msgstr ""
-
-#: lib/diff.tcl:591
-msgid "Failed to revert selected hunk."
-msgstr ""
-
-#: lib/diff.tcl:594
-msgid "Failed to stage selected hunk."
-msgstr ""
-
-#: lib/diff.tcl:687
-msgid "Failed to unstage selected line."
-msgstr ""
-
-#: lib/diff.tcl:696
-msgid "Failed to revert selected line."
-msgstr ""
-
-#: lib/diff.tcl:700
-msgid "Failed to stage selected line."
-msgstr ""
-
-#: lib/diff.tcl:889
-msgid "Failed to undo last revert."
-msgstr ""
-
-#: lib/sshkey.tcl:34
-msgid "No keys found."
-msgstr ""
-
-#: lib/sshkey.tcl:37
-#, tcl-format
-msgid "Found a public key in: %s"
-msgstr ""
-
-#: lib/sshkey.tcl:43
-msgid "Generate Key"
-msgstr ""
-
-#: lib/sshkey.tcl:61
-msgid "Copy To Clipboard"
-msgstr ""
-
-#: lib/sshkey.tcl:75
-msgid "Your OpenSSH Public Key"
-msgstr ""
-
-#: lib/sshkey.tcl:83
-msgid "Generating..."
-msgstr ""
-
-#: lib/sshkey.tcl:89
-#, tcl-format
-msgid ""
-"Could not start ssh-keygen:\n"
-"\n"
-"%s"
-msgstr ""
-
-#: lib/sshkey.tcl:116
-msgid "Generation failed."
-msgstr ""
-
-#: lib/sshkey.tcl:123
-msgid "Generation succeeded, but no keys found."
-msgstr ""
-
-#: lib/sshkey.tcl:126
-#, tcl-format
-msgid "Your key is in: %s"
-msgstr ""
-
-#: lib/branch_create.tcl:23
-#, tcl-format
-msgid "%s (%s): Create Branch"
-msgstr ""
-
-#: lib/branch_create.tcl:28
-msgid "Create New Branch"
-msgstr ""
-
-#: lib/branch_create.tcl:42
-msgid "Branch Name"
-msgstr ""
-
-#: lib/branch_create.tcl:57
-msgid "Match Tracking Branch Name"
-msgstr ""
-
-#: lib/branch_create.tcl:66
-msgid "Starting Revision"
-msgstr ""
-
-#: lib/branch_create.tcl:72
-msgid "Update Existing Branch:"
-msgstr ""
-
-#: lib/branch_create.tcl:75
-msgid "No"
-msgstr ""
-
-#: lib/branch_create.tcl:80
-msgid "Fast Forward Only"
-msgstr ""
-
-#: lib/branch_create.tcl:97
-msgid "Checkout After Creation"
-msgstr ""
-
-#: lib/branch_create.tcl:132
-msgid "Please select a tracking branch."
-msgstr ""
-
-#: lib/branch_create.tcl:141
-#, tcl-format
-msgid "Tracking branch %s is not a branch in the remote repository."
-msgstr ""
-
-#: lib/console.tcl:59
-msgid "Working... please wait..."
-msgstr ""
-
-#: lib/console.tcl:186
-msgid "Success"
-msgstr ""
-
-#: lib/console.tcl:200
-msgid "Error: Command Failed"
-msgstr ""
-
-#: lib/line.tcl:17
-msgid "Goto Line:"
-msgstr ""
-
-#: lib/line.tcl:23
-msgid "Go"
 msgstr ""
 
 #: lib/choose_rev.tcl:52
@@ -2433,48 +1490,21 @@ msgstr ""
 msgid "update-ref failed:"
 msgstr ""
 
-#: lib/commit.tcl:514
+#: lib/commit.tcl:515
 #, tcl-format
 msgid "Created commit %s: %s"
 msgstr ""
 
-#: lib/branch_delete.tcl:16
-#, tcl-format
-msgid "%s (%s): Delete Branch"
+#: lib/console.tcl:59
+msgid "Working... please wait..."
 msgstr ""
 
-#: lib/branch_delete.tcl:21
-msgid "Delete Local Branch"
+#: lib/console.tcl:186
+msgid "Success"
 msgstr ""
 
-#: lib/branch_delete.tcl:39
-msgid "Local Branches"
-msgstr ""
-
-#: lib/branch_delete.tcl:51
-msgid "Delete Only If Merged Into"
-msgstr ""
-
-#: lib/branch_delete.tcl:103
-#, tcl-format
-msgid "The following branches are not completely merged into %s:"
-msgstr ""
-
-#: lib/branch_delete.tcl:131
-#, tcl-format
-msgid " - %s:"
-msgstr ""
-
-#: lib/branch_delete.tcl:141
-#, tcl-format
-msgid ""
-"Failed to delete branches:\n"
-"%s"
-msgstr ""
-
-#: lib/date.tcl:25
-#, tcl-format
-msgid "Invalid date from Git: %s"
+#: lib/console.tcl:200
+msgid "Error: Command Failed"
 msgstr ""
 
 #: lib/database.tcl:42
@@ -2505,6 +1535,12 @@ msgstr ""
 msgid "Garbage files"
 msgstr ""
 
+#: lib/database.tcl:57 lib/option.tcl:183 lib/option.tcl:198 lib/option.tcl:221
+#: lib/option.tcl:283
+#, tcl-format
+msgid "%s:"
+msgstr ""
+
 #: lib/database.tcl:66
 #, tcl-format
 msgid "%s (%s): Database Statistics"
@@ -2529,6 +1565,123 @@ msgid ""
 "Compress the database now?"
 msgstr ""
 
+#: lib/date.tcl:25
+#, tcl-format
+msgid "Invalid date from Git: %s"
+msgstr ""
+
+#: lib/diff.tcl:77
+#, tcl-format
+msgid ""
+"No differences detected.\n"
+"\n"
+"%s has no changes.\n"
+"\n"
+"The modification date of this file was updated by another application, but "
+"the content within the file was not changed.\n"
+"\n"
+"A rescan will be automatically started to find other files which may have "
+"the same state."
+msgstr ""
+
+#: lib/diff.tcl:117
+#, tcl-format
+msgid "Loading diff of %s..."
+msgstr ""
+
+#: lib/diff.tcl:143
+msgid ""
+"LOCAL: deleted\n"
+"REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:148
+msgid ""
+"REMOTE: deleted\n"
+"LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:155
+msgid "LOCAL:\n"
+msgstr ""
+
+#: lib/diff.tcl:158
+msgid "REMOTE:\n"
+msgstr ""
+
+#: lib/diff.tcl:220 lib/diff.tcl:344
+#, tcl-format
+msgid "Unable to display %s"
+msgstr ""
+
+#: lib/diff.tcl:221
+msgid "Error loading file:"
+msgstr ""
+
+#: lib/diff.tcl:227
+msgid "Git Repository (subproject)"
+msgstr ""
+
+#: lib/diff.tcl:239
+msgid "* Binary file (not showing content)."
+msgstr ""
+
+#: lib/diff.tcl:244
+#, tcl-format
+msgid ""
+"* Untracked file is %d bytes.\n"
+"* Showing only first %d bytes.\n"
+msgstr ""
+
+#: lib/diff.tcl:250
+#, tcl-format
+msgid ""
+"\n"
+"* Untracked file clipped here by %s.\n"
+"* To see the entire file, use an external editor.\n"
+msgstr ""
+
+#: lib/diff.tcl:583
+msgid "Failed to unstage selected hunk."
+msgstr ""
+
+#: lib/diff.tcl:591
+msgid "Failed to revert selected hunk."
+msgstr ""
+
+#: lib/diff.tcl:594
+msgid "Failed to stage selected hunk."
+msgstr ""
+
+#: lib/diff.tcl:687
+msgid "Failed to unstage selected line."
+msgstr ""
+
+#: lib/diff.tcl:696
+msgid "Failed to revert selected line."
+msgstr ""
+
+#: lib/diff.tcl:700
+msgid "Failed to stage selected line."
+msgstr ""
+
+#: lib/diff.tcl:889
+msgid "Failed to undo last revert."
+msgstr ""
+
+#: lib/encoding.tcl:443
+msgid "Default"
+msgstr ""
+
+#: lib/encoding.tcl:448
+#, tcl-format
+msgid "System (%s)"
+msgstr ""
+
+#: lib/encoding.tcl:459 lib/encoding.tcl:465
+msgid "Other"
+msgstr ""
+
 #: lib/error.tcl:20
 #, tcl-format
 msgid "%s: error"
@@ -2551,6 +1704,130 @@ msgstr ""
 #: lib/error.tcl:116
 #, tcl-format
 msgid "%s (%s): error"
+msgstr ""
+
+#: lib/index.tcl:6
+msgid "Unable to unlock the index."
+msgstr ""
+
+#: lib/index.tcl:30
+msgid "Index Error"
+msgstr ""
+
+#: lib/index.tcl:32
+msgid ""
+"Updating the Git index failed.  A rescan will be automatically started to "
+"resynchronize git-gui."
+msgstr ""
+
+#: lib/index.tcl:43
+msgid "Continue"
+msgstr ""
+
+#: lib/index.tcl:46
+msgid "Unlock Index"
+msgstr ""
+
+#: lib/index.tcl:326
+msgid "Unstaging selected files from commit"
+msgstr ""
+
+#: lib/index.tcl:330
+#, tcl-format
+msgid "Unstaging %s from commit"
+msgstr ""
+
+#: lib/index.tcl:369
+msgid "Ready to commit."
+msgstr ""
+
+#: lib/index.tcl:378
+msgid "Adding selected files"
+msgstr ""
+
+#: lib/index.tcl:382
+#, tcl-format
+msgid "Adding %s"
+msgstr ""
+
+#: lib/index.tcl:412
+#, tcl-format
+msgid "Stage %d untracked files?"
+msgstr ""
+
+#: lib/index.tcl:420
+msgid "Adding all changed files"
+msgstr ""
+
+#: lib/index.tcl:503
+#, tcl-format
+msgid "Revert changes in file %s?"
+msgstr ""
+
+#: lib/index.tcl:508
+#, tcl-format
+msgid "Revert changes in these %i files?"
+msgstr ""
+
+#: lib/index.tcl:517
+msgid "Any unstaged changes will be permanently lost by the revert."
+msgstr ""
+
+#: lib/index.tcl:520 lib/index.tcl:564
+msgid "Do Nothing"
+msgstr ""
+
+#: lib/index.tcl:546
+#, tcl-format
+msgid "Delete untracked file %s?"
+msgstr ""
+
+#: lib/index.tcl:551
+#, tcl-format
+msgid "Delete these %i untracked files?"
+msgstr ""
+
+#: lib/index.tcl:561
+msgid "Files will be permanently deleted."
+msgstr ""
+
+#: lib/index.tcl:565
+msgid "Delete Files"
+msgstr ""
+
+#: lib/index.tcl:588
+msgid "Deleting"
+msgstr ""
+
+#: lib/index.tcl:667
+msgid "Encountered errors deleting files:\n"
+msgstr ""
+
+#: lib/index.tcl:676
+#, tcl-format
+msgid "None of the %d selected files could be deleted."
+msgstr ""
+
+#: lib/index.tcl:681
+#, tcl-format
+msgid "%d of the %d selected files could not be deleted."
+msgstr ""
+
+#: lib/index.tcl:728
+msgid "Reverting selected files"
+msgstr ""
+
+#: lib/index.tcl:732
+#, tcl-format
+msgid "Reverting %s"
+msgstr ""
+
+#: lib/line.tcl:17
+msgid "Goto Line:"
+msgstr ""
+
+#: lib/line.tcl:23
+msgid "Go"
 msgstr ""
 
 #: lib/merge.tcl:13
@@ -2663,4 +1940,731 @@ msgstr ""
 
 #: lib/merge.tcl:279
 msgid "Abort completed.  Ready."
+msgstr ""
+
+#: lib/mergetool.tcl:8
+msgid "Force resolution to the base version?"
+msgstr ""
+
+#: lib/mergetool.tcl:9
+msgid "Force resolution to this branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:10
+msgid "Force resolution to the other branch?"
+msgstr ""
+
+#: lib/mergetool.tcl:14
+#, tcl-format
+msgid ""
+"Note that the diff shows only conflicting changes.\n"
+"\n"
+"%s will be overwritten.\n"
+"\n"
+"This operation can be undone only by restarting the merge."
+msgstr ""
+
+#: lib/mergetool.tcl:45
+#, tcl-format
+msgid "File %s seems to have unresolved conflicts, still stage?"
+msgstr ""
+
+#: lib/mergetool.tcl:60
+#, tcl-format
+msgid "Adding resolution for %s"
+msgstr ""
+
+#: lib/mergetool.tcl:141
+msgid "Cannot resolve deletion or link conflicts using a tool"
+msgstr ""
+
+#: lib/mergetool.tcl:146
+msgid "Conflict file does not exist"
+msgstr ""
+
+#: lib/mergetool.tcl:246
+#, tcl-format
+msgid "Not a GUI merge tool: '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:275
+#, tcl-format
+msgid "Unsupported merge tool '%s'"
+msgstr ""
+
+#: lib/mergetool.tcl:310
+msgid "Merge tool is already running, terminate it?"
+msgstr ""
+
+#: lib/mergetool.tcl:330
+#, tcl-format
+msgid ""
+"Error retrieving versions:\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:350
+#, tcl-format
+msgid ""
+"Could not start the merge tool:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/mergetool.tcl:354
+msgid "Running merge tool..."
+msgstr ""
+
+#: lib/mergetool.tcl:382 lib/mergetool.tcl:390
+msgid "Merge tool failed."
+msgstr ""
+
+#: lib/option.tcl:11
+#, tcl-format
+msgid "Invalid global encoding '%s'"
+msgstr ""
+
+#: lib/option.tcl:19
+#, tcl-format
+msgid "Invalid repo encoding '%s'"
+msgstr ""
+
+#: lib/option.tcl:119
+msgid "Restore Defaults"
+msgstr ""
+
+#: lib/option.tcl:123
+msgid "Save"
+msgstr ""
+
+#: lib/option.tcl:133
+#, tcl-format
+msgid "%s Repository"
+msgstr ""
+
+#: lib/option.tcl:134
+msgid "Global (All Repositories)"
+msgstr ""
+
+#: lib/option.tcl:140
+msgid "User Name"
+msgstr ""
+
+#: lib/option.tcl:141
+msgid "Email Address"
+msgstr ""
+
+#: lib/option.tcl:143
+msgid "Summarize Merge Commits"
+msgstr ""
+
+#: lib/option.tcl:144
+msgid "Merge Verbosity"
+msgstr ""
+
+#: lib/option.tcl:145
+msgid "Show Diffstat After Merge"
+msgstr ""
+
+#: lib/option.tcl:146
+msgid "Use Merge Tool"
+msgstr ""
+
+#: lib/option.tcl:148
+msgid "Trust File Modification Timestamps"
+msgstr ""
+
+#: lib/option.tcl:149
+msgid "Prune Tracking Branches During Fetch"
+msgstr ""
+
+#: lib/option.tcl:150
+msgid "Match Tracking Branches"
+msgstr ""
+
+#: lib/option.tcl:151
+msgid "Use Textconv For Diffs and Blames"
+msgstr ""
+
+#: lib/option.tcl:152
+msgid "Blame Copy Only On Changed Files"
+msgstr ""
+
+#: lib/option.tcl:153
+msgid "Maximum Length of Recent Repositories List"
+msgstr ""
+
+#: lib/option.tcl:154
+msgid "Minimum Letters To Blame Copy On"
+msgstr ""
+
+#: lib/option.tcl:155
+msgid "Blame History Context Radius (days)"
+msgstr ""
+
+#: lib/option.tcl:156
+msgid "Number of Diff Context Lines"
+msgstr ""
+
+#: lib/option.tcl:157
+msgid "Additional Diff Parameters"
+msgstr ""
+
+#: lib/option.tcl:158
+msgid "Commit Message Text Width"
+msgstr ""
+
+#: lib/option.tcl:159
+msgid "Commit Message Wrap Lines"
+msgstr ""
+
+#: lib/option.tcl:160
+msgid "New Branch Name Template"
+msgstr ""
+
+#: lib/option.tcl:161
+msgid "Default File Contents Encoding"
+msgstr ""
+
+#: lib/option.tcl:162
+msgid "Warn before committing to a detached head"
+msgstr ""
+
+#: lib/option.tcl:163
+msgid "Staging of untracked files"
+msgstr ""
+
+#: lib/option.tcl:164
+msgid "Show untracked files"
+msgstr ""
+
+#: lib/option.tcl:165
+msgid "Tab spacing"
+msgstr ""
+
+#: lib/option.tcl:211
+msgid "Change"
+msgstr ""
+
+#: lib/option.tcl:255
+msgid "Spelling Dictionary:"
+msgstr ""
+
+#: lib/option.tcl:285
+msgid "Change Font"
+msgstr ""
+
+#: lib/option.tcl:289
+#, tcl-format
+msgid "Choose %s"
+msgstr ""
+
+#: lib/option.tcl:295
+msgid "pt."
+msgstr ""
+
+#: lib/option.tcl:309
+msgid "Preferences"
+msgstr ""
+
+#: lib/option.tcl:346
+msgid "Failed to completely save options:"
+msgstr ""
+
+#: lib/remote.tcl:200
+msgid "Push to"
+msgstr ""
+
+#: lib/remote.tcl:218
+msgid "Remove Remote"
+msgstr ""
+
+#: lib/remote.tcl:223
+msgid "Prune from"
+msgstr ""
+
+#: lib/remote.tcl:228
+msgid "Fetch from"
+msgstr ""
+
+#: lib/remote.tcl:249 lib/remote.tcl:253 lib/remote.tcl:258 lib/remote.tcl:264
+msgid "All"
+msgstr ""
+
+#: lib/remote_add.tcl:20
+#, tcl-format
+msgid "%s (%s): Add Remote"
+msgstr ""
+
+#: lib/remote_add.tcl:25
+msgid "Add New Remote"
+msgstr ""
+
+#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
+msgid "Add"
+msgstr ""
+
+#: lib/remote_add.tcl:39
+msgid "Remote Details"
+msgstr ""
+
+#: lib/remote_add.tcl:50
+msgid "Location:"
+msgstr ""
+
+#: lib/remote_add.tcl:60
+msgid "Further Action"
+msgstr ""
+
+#: lib/remote_add.tcl:63
+msgid "Fetch Immediately"
+msgstr ""
+
+#: lib/remote_add.tcl:69
+msgid "Initialize Remote Repository and Push"
+msgstr ""
+
+#: lib/remote_add.tcl:75
+msgid "Do Nothing Else Now"
+msgstr ""
+
+#: lib/remote_add.tcl:100
+msgid "Please supply a remote name."
+msgstr ""
+
+#: lib/remote_add.tcl:113
+#, tcl-format
+msgid "'%s' is not an acceptable remote name."
+msgstr ""
+
+#: lib/remote_add.tcl:124
+#, tcl-format
+msgid "Failed to add remote '%s' of location '%s'."
+msgstr ""
+
+#: lib/remote_add.tcl:132 lib/transport.tcl:6
+#, tcl-format
+msgid "fetch %s"
+msgstr ""
+
+#: lib/remote_add.tcl:133
+#, tcl-format
+msgid "Fetching the %s"
+msgstr ""
+
+#: lib/remote_add.tcl:156
+#, tcl-format
+msgid "Do not know how to initialize repository at location '%s'."
+msgstr ""
+
+#: lib/remote_add.tcl:162 lib/transport.tcl:54 lib/transport.tcl:92
+#: lib/transport.tcl:110
+#, tcl-format
+msgid "push %s"
+msgstr ""
+
+#: lib/remote_add.tcl:163
+#, tcl-format
+msgid "Setting up the %s (at %s)"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:29
+#, tcl-format
+msgid "%s (%s): Delete Branch Remotely"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:34
+msgid "Delete Branch Remotely"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:48
+msgid "From Repository"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:51 lib/transport.tcl:165
+msgid "Remote:"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:72 lib/transport.tcl:187
+msgid "Arbitrary Location:"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:88
+msgid "Branches"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:110
+msgid "Delete Only If"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:112
+msgid "Merged Into:"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:153
+msgid "A branch is required for 'Merged Into'."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:185
+#, tcl-format
+msgid ""
+"The following branches are not completely merged into %s:\n"
+"\n"
+" - %s"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:190
+#, tcl-format
+msgid ""
+"One or more of the merge tests failed because you have not fetched the "
+"necessary commits.  Try fetching from %s first."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:208
+msgid "Please select one or more branches to delete."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:227
+#, tcl-format
+msgid "Deleting branches from %s"
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:300
+msgid "No repository selected."
+msgstr ""
+
+#: lib/remote_branch_delete.tcl:305
+#, tcl-format
+msgid "Scanning %s..."
+msgstr ""
+
+#: lib/search.tcl:48
+msgid "Find:"
+msgstr ""
+
+#: lib/search.tcl:50
+msgid "Next"
+msgstr ""
+
+#: lib/search.tcl:51
+msgid "Prev"
+msgstr ""
+
+#: lib/search.tcl:52
+msgid "RegExp"
+msgstr ""
+
+#: lib/search.tcl:54
+msgid "Case"
+msgstr ""
+
+#: lib/shortcut.tcl:8 lib/shortcut.tcl:43 lib/shortcut.tcl:75
+#, tcl-format
+msgid "%s (%s): Create Desktop Icon"
+msgstr ""
+
+#: lib/shortcut.tcl:24 lib/shortcut.tcl:65
+msgid "Cannot write shortcut:"
+msgstr ""
+
+#: lib/shortcut.tcl:140
+msgid "Cannot write icon:"
+msgstr ""
+
+#: lib/spellcheck.tcl:57
+msgid "Unsupported spell checker"
+msgstr ""
+
+#: lib/spellcheck.tcl:65
+msgid "Spell checking is unavailable"
+msgstr ""
+
+#: lib/spellcheck.tcl:68
+msgid "Invalid spell checking configuration"
+msgstr ""
+
+#: lib/spellcheck.tcl:70
+#, tcl-format
+msgid "Reverting dictionary to %s."
+msgstr ""
+
+#: lib/spellcheck.tcl:73
+msgid "Spell checker silently failed on startup"
+msgstr ""
+
+#: lib/spellcheck.tcl:80
+msgid "Unrecognized spell checker"
+msgstr ""
+
+#: lib/spellcheck.tcl:186
+msgid "No Suggestions"
+msgstr ""
+
+#: lib/spellcheck.tcl:388
+msgid "Unexpected EOF from spell checker"
+msgstr ""
+
+#: lib/spellcheck.tcl:392
+msgid "Spell Checker Failed"
+msgstr ""
+
+#: lib/sshkey.tcl:34
+msgid "No keys found."
+msgstr ""
+
+#: lib/sshkey.tcl:37
+#, tcl-format
+msgid "Found a public key in: %s"
+msgstr ""
+
+#: lib/sshkey.tcl:43
+msgid "Generate Key"
+msgstr ""
+
+#: lib/sshkey.tcl:61
+msgid "Copy To Clipboard"
+msgstr ""
+
+#: lib/sshkey.tcl:75
+msgid "Your OpenSSH Public Key"
+msgstr ""
+
+#: lib/sshkey.tcl:83
+msgid "Generating..."
+msgstr ""
+
+#: lib/sshkey.tcl:89
+#, tcl-format
+msgid ""
+"Could not start ssh-keygen:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: lib/sshkey.tcl:116
+msgid "Generation failed."
+msgstr ""
+
+#: lib/sshkey.tcl:123
+msgid "Generation succeeded, but no keys found."
+msgstr ""
+
+#: lib/sshkey.tcl:126
+#, tcl-format
+msgid "Your key is in: %s"
+msgstr ""
+
+#: lib/status_bar.tcl:263
+#, tcl-format
+msgid "%s ... %*i of %*i %s (%3i%%)"
+msgstr ""
+
+#: lib/tools.tcl:76
+#, tcl-format
+msgid "Running %s requires a selected file."
+msgstr ""
+
+#: lib/tools.tcl:92
+#, tcl-format
+msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
+msgstr ""
+
+#: lib/tools.tcl:96
+#, tcl-format
+msgid "Are you sure you want to run %s?"
+msgstr ""
+
+#: lib/tools.tcl:118
+#, tcl-format
+msgid "Tool: %s"
+msgstr ""
+
+#: lib/tools.tcl:119
+#, tcl-format
+msgid "Running: %s"
+msgstr ""
+
+#: lib/tools.tcl:158
+#, tcl-format
+msgid "Tool completed successfully: %s"
+msgstr ""
+
+#: lib/tools.tcl:160
+#, tcl-format
+msgid "Tool failed: %s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:22
+#, tcl-format
+msgid "%s (%s): Add Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:28
+msgid "Add New Tool Command"
+msgstr ""
+
+#: lib/tools_dlg.tcl:34
+msgid "Add globally"
+msgstr ""
+
+#: lib/tools_dlg.tcl:46
+msgid "Tool Details"
+msgstr ""
+
+#: lib/tools_dlg.tcl:49
+msgid "Use '/' separators to create a submenu tree:"
+msgstr ""
+
+#: lib/tools_dlg.tcl:60
+msgid "Command:"
+msgstr ""
+
+#: lib/tools_dlg.tcl:71
+msgid "Show a dialog before running"
+msgstr ""
+
+#: lib/tools_dlg.tcl:77
+msgid "Ask the user to select a revision (sets $REVISION)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:82
+msgid "Ask the user for additional arguments (sets $ARGS)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:89
+msgid "Don't show the command output window"
+msgstr ""
+
+#: lib/tools_dlg.tcl:94
+msgid "Run only if a diff is selected ($FILENAME not empty)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:118
+msgid "Please supply a name for the tool."
+msgstr ""
+
+#: lib/tools_dlg.tcl:126
+#, tcl-format
+msgid "Tool '%s' already exists."
+msgstr ""
+
+#: lib/tools_dlg.tcl:148
+#, tcl-format
+msgid ""
+"Could not add tool:\n"
+"%s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:187
+#, tcl-format
+msgid "%s (%s): Remove Tool"
+msgstr ""
+
+#: lib/tools_dlg.tcl:193
+msgid "Remove Tool Commands"
+msgstr ""
+
+#: lib/tools_dlg.tcl:198
+msgid "Remove"
+msgstr ""
+
+#: lib/tools_dlg.tcl:231
+msgid "(Blue denotes repository-local tools)"
+msgstr ""
+
+#: lib/tools_dlg.tcl:283
+#, tcl-format
+msgid "%s (%s):"
+msgstr ""
+
+#: lib/tools_dlg.tcl:292
+#, tcl-format
+msgid "Run Command: %s"
+msgstr ""
+
+#: lib/tools_dlg.tcl:306
+msgid "Arguments"
+msgstr ""
+
+#: lib/tools_dlg.tcl:341
+msgid "OK"
+msgstr ""
+
+#: lib/transport.tcl:7
+#, tcl-format
+msgid "Fetching new changes from %s"
+msgstr ""
+
+#: lib/transport.tcl:18
+#, tcl-format
+msgid "remote prune %s"
+msgstr ""
+
+#: lib/transport.tcl:19
+#, tcl-format
+msgid "Pruning tracking branches deleted from %s"
+msgstr ""
+
+#: lib/transport.tcl:25
+msgid "fetch all remotes"
+msgstr ""
+
+#: lib/transport.tcl:26
+msgid "Fetching new changes from all remotes"
+msgstr ""
+
+#: lib/transport.tcl:40
+msgid "remote prune all remotes"
+msgstr ""
+
+#: lib/transport.tcl:41
+msgid "Pruning tracking branches deleted from all remotes"
+msgstr ""
+
+#: lib/transport.tcl:55
+#, tcl-format
+msgid "Pushing changes to %s"
+msgstr ""
+
+#: lib/transport.tcl:93
+#, tcl-format
+msgid "Mirroring to %s"
+msgstr ""
+
+#: lib/transport.tcl:111
+#, tcl-format
+msgid "Pushing %s %s to %s"
+msgstr ""
+
+#: lib/transport.tcl:132
+msgid "Push Branches"
+msgstr ""
+
+#: lib/transport.tcl:147
+msgid "Source Branches"
+msgstr ""
+
+#: lib/transport.tcl:162
+msgid "Destination Repository"
+msgstr ""
+
+#: lib/transport.tcl:205
+msgid "Transfer Options"
+msgstr ""
+
+#: lib/transport.tcl:207
+msgid "Force overwrite existing branch (may discard changes)"
+msgstr ""
+
+#: lib/transport.tcl:211
+msgid "Use thin pack (for slow network connections)"
+msgstr ""
+
+#: lib/transport.tcl:215
+msgid "Include tags"
+msgstr ""
+
+#: lib/transport.tcl:229
+#, tcl-format
+msgid "%s (%s): Push"
 msgstr ""


### PR DESCRIPTION
If a source hoster renders commit messages with lines as paragraphs, newlines can be visually relevant. Then to avoid pointless paragraph breaks, I have to write very long commit lines. To make this easier, add `gui.commitmsgwrap` to set the commit message window to linewrap on words.