### PR TITLE
Use gui.encoding for showing console output

### DIFF
--- a/lib/console.tcl
+++ b/lib/console.tcl
@@ -97,7 +97,13 @@ method exec {cmd {after {}}} {
 		lappend cmd 2>@1
 		set fd_f [_open_stdout_stderr $cmd]
 	}
-	fconfigure $fd_f -blocking 0 -translation binary
+
+	set enc [tcl_encoding [get_config gui.encoding]]
+	if {$enc eq {}} {
+		set enc ascii
+	}
+
+	fconfigure $fd_f -blocking 0 -translation binary -encoding $enc
 	fileevent $fd_f readable [cb _read $fd_f $after]
 }
 


### PR DESCRIPTION
This patch fixes issue https://github.com/prati0100/git-gui/issues/68
I used `gui.encoding` as console encoding, but it can be better to introduce new option eg `gui.console-encoding` for it.